### PR TITLE
Define database schema for virtual assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "typeorm-ts-node-commonjs",
+    "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",
+    "migration:run": "npm run typeorm -- migration:run -d src/database/data-source.ts",
+    "migration:revert": "npm run typeorm -- migration:revert -d src/database/data-source.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/src/balance/entities/user-balance.entity.ts
+++ b/src/balance/entities/user-balance.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { User } from '../../user/entities/user.entity';
+import { VirtualAsset } from '../../trading/entities/virtual-asset.entity';
+
+@Entity('user_balances')
+@Unique(['userId', 'assetId'])
+export class UserBalance {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index()
+  @Column()
+  userId: number;
+
+  @Index()
+  @Column()
+  assetId: number;
+
+  @Column('decimal', { precision: 15, scale: 8, default: 0 })
+  balance: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @ManyToOne(() => VirtualAsset)
+  @JoinColumn({ name: 'assetId' })
+  asset: VirtualAsset;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,0 +1,30 @@
+import { DataSource } from 'typeorm';
+import { VirtualAsset } from '../trading/entities/virtual-asset.entity';
+import { UserBalance } from '../balance/entities/user-balance.entity';
+import { User } from '../user/entities/user.entity';
+import { Trade } from '../trading/entities/trade.entity';
+import { Balance } from '../balance/balance.entity';
+import { Portfolio } from '../portfolio/entities/portfolio.entity';
+import { Reward } from '../rewards/entities/reward.entity';
+import { Notification } from '../notification/entities/notification.entity';
+import { Bid } from '../bidding/entities/bid.entity';
+
+export const AppDataSource = new DataSource({
+  type: 'sqlite',
+  database: 'swaptrade.db',
+  entities: [
+    VirtualAsset,
+    UserBalance,
+    User,
+    Trade,
+    Balance,
+    Portfolio,
+    Reward,
+    Notification,
+    Bid,
+  ],
+  migrations: ['src/database/migrations/*.ts'],
+  migrationsTableName: 'migrations',
+  synchronize: false, // Set to false when using migrations
+  logging: true,
+});

--- a/src/database/migrations/1727516400000-CreateVirtualAssetsAndUserBalances.ts
+++ b/src/database/migrations/1727516400000-CreateVirtualAssetsAndUserBalances.ts
@@ -1,0 +1,131 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateVirtualAssetsAndUserBalances1727516400000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create virtual_assets table
+    await queryRunner.createTable(
+      new Table({
+        name: 'virtual_assets',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'symbol',
+            type: 'varchar',
+            isUnique: true,
+            isNullable: false,
+          },
+          {
+            name: 'name',
+            type: 'varchar',
+            isNullable: false,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        indices: [
+          {
+            name: 'IDX_virtual_assets_symbol',
+            columnNames: ['symbol'],
+            isUnique: true,
+          },
+        ],
+      }),
+    );
+
+    // Create user_balances table
+    await queryRunner.createTable(
+      new Table({
+        name: 'user_balances',
+        columns: [
+          {
+            name: 'id',
+            type: 'integer',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'userId',
+            type: 'integer',
+            isNullable: false,
+          },
+          {
+            name: 'assetId',
+            type: 'integer',
+            isNullable: false,
+          },
+          {
+            name: 'balance',
+            type: 'decimal',
+            precision: 15,
+            scale: 8,
+            default: 0,
+          },
+          {
+            name: 'createdAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['userId'],
+            referencedTableName: 'user',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['assetId'],
+            referencedTableName: 'virtual_assets',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+        indices: [
+          {
+            name: 'IDX_user_balances_userId',
+            columnNames: ['userId'],
+          },
+          {
+            name: 'IDX_user_balances_assetId',
+            columnNames: ['assetId'],
+          },
+          {
+            name: 'IDX_user_balances_userId_assetId',
+            columnNames: ['userId', 'assetId'],
+            isUnique: true,
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop user_balances table (this will also drop its indexes and foreign keys)
+    await queryRunner.dropTable('user_balances');
+
+    // Drop virtual_assets table (this will also drop its indexes)
+    await queryRunner.dropTable('virtual_assets');
+  }
+}

--- a/src/trading/entities/virtual-asset.entity.ts
+++ b/src/trading/entities/virtual-asset.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('virtual_assets')
+export class VirtualAsset {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Index({ unique: true })
+  @Column({ unique: true })
+  symbol: string;
+
+  @Column()
+  name: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
This PR implements the database schema for virtual assets and user balances as requested in issue #35. It introduces TypeORM entities and migrations to support the core trading functionality.

## Changes Made

### 📋 Entity Definitions
- **VirtualAsset Entity** (`src/trading/entities/virtual-asset.entity.ts`)
  - Primary key: `id` (auto-generated)
  - `symbol` - unique asset identifier (e.g., "BTC", "ETH")
  - `name` - human-readable asset name
  - Timestamps: `createdAt`, `updatedAt`
  - Unique index on `symbol` for fast lookups

- **UserBalance Entity** (`src/balance/entities/user-balance.entity.ts`)
  - Primary key: `id` (auto-generated)
  - `userId` - foreign key to User entity
  - `assetId` - foreign key to VirtualAsset entity
  - `balance` - decimal field (precision: 15, scale: 8) for high-precision amounts
  - Unique constraint on `[userId, assetId]` to prevent duplicate balances
  - Proper many-to-one relationships with User and VirtualAsset entities
  - Indexes on `userId` and `assetId` for query optimization

### 🗃️ Database Configuration
- **Data Source Setup** (`src/database/data-source.ts`)
  - Configured SQLite database connection
  - Registered all entities including the new VirtualAsset and UserBalance
  - Migration configuration with proper table naming
  - Disabled synchronization in favor of migration-based schema management

### 🔄 Migration
- **Migration File** (`src/database/migrations/1727516400000-CreateVirtualAssetsAndUserBalances.ts`)
  - Creates `virtual_assets` table with proper constraints
  - Creates `user_balances` table with foreign key relationships
  - Implements proper indexes for performance:
    - Unique index on `virtual_assets.symbol`
    - Composite unique index on `user_balances.[userId, assetId]`
    - Individual indexes on foreign key columns
  - Includes proper rollback functionality in `down()` method

### 🛠️ Development Tools
- **Package.json Updates**
  - Added TypeORM CLI scripts for migration management
  - `migration:generate` - Generate new migrations
  - `migration:run` - Execute pending migrations
  - `migration:revert` - Rollback last migration

Closes #35