### PR TITLE
Create badge

### DIFF
--- a/src/rewards/controllers/badge.controller.ts
+++ b/src/rewards/controllers/badge.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { UserBadgeService } from '../services/user-badge.service';
+
+@Controller('badges')
+export class BadgeController {
+  constructor(private readonly userBadgeService: UserBadgeService) {}
+
+  @Get(':userId')
+  async getUserBadges(@Param('userId', ParseIntPipe) userId: number) {
+    const badges = await this.userBadgeService.findByUserId(userId);
+    return badges.map((b) => ({ id: b.id, badge: b.badge, awardedAt: b.awardedAt }));
+  }
+}
+
+

--- a/src/rewards/entities/user-badge.entity.ts
+++ b/src/rewards/entities/user-badge.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity()
+export class UserBadge {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: number;
+
+  @Column()
+  badge: string;
+
+  @CreateDateColumn()
+  awardedAt: Date;
+}
+
+

--- a/src/rewards/rewards.module.ts
+++ b/src/rewards/rewards.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { RewardsController } from './rewards.controller';
 import { RewardsService } from './rewards.service';
+import { BadgeController } from './controllers/badge.controller';
+import { UserBadgeService } from './services/user-badge.service';
+import { UserBadge } from './entities/user-badge.entity';
 
 @Module({
-  controllers: [RewardsController],
-  providers: [RewardsService],
+  imports: [TypeOrmModule.forFeature([UserBadge])],
+  controllers: [RewardsController, BadgeController],
+  providers: [RewardsService, UserBadgeService],
 })
 export class RewardsModule {}

--- a/src/rewards/services/user-badge.service.ts
+++ b/src/rewards/services/user-badge.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserBadge } from '../entities/user-badge.entity';
+
+@Injectable()
+export class UserBadgeService {
+  constructor(
+    @InjectRepository(UserBadge)
+    private readonly userBadgeRepository: Repository<UserBadge>,
+  ) {}
+
+  async findByUserId(userId: number): Promise<UserBadge[]> {
+    return this.userBadgeRepository.find({ where: { userId } });
+  }
+}
+
+

--- a/test/badges.e2e-spec.ts
+++ b/test/badges.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserBadge } from '../src/rewards/entities/user-badge.entity';
+
+describe('BadgeController (e2e)', () => {
+  let app: INestApplication;
+  let userBadgeRepository: Repository<UserBadge>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    userBadgeRepository = moduleFixture.get<Repository<UserBadge>>(getRepositoryToken(UserBadge));
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/badges/:userId (GET) returns empty array when no badges', async () => {
+    const userId = 999999; // unlikely to collide; tests clean up specific records
+    await userBadgeRepository.delete({ userId });
+
+    const res = await request(app.getHttpServer())
+      .get(`/badges/${userId}`)
+      .expect(200);
+
+    expect(res.body).toEqual([]);
+  });
+
+  it('/badges/:userId (GET) returns awarded badges', async () => {
+    const userId = 424242;
+    await userBadgeRepository.delete({ userId });
+
+    const created = await userBadgeRepository.save({ userId, badge: 'EarlyBird' });
+
+    const res = await request(app.getHttpServer())
+      .get(`/badges/${userId}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+    expect(res.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: created.id, badge: 'EarlyBird' }),
+      ]),
+    );
+
+    await userBadgeRepository.delete({ userId });
+  });
+});
+
+


### PR DESCRIPTION
### PR Title
Expose endpoint to fetch user badges (closes #42)

### Summary
- Adds GET `/badges/:userId` endpoint to return awarded badges for a user.
- Returns an empty array when no badges are awarded.

### Changes
- Rewards
  - Added `UserBadge` entity.
  - Implemented `UserBadgeService` with `findByUserId`.
  - Added `BadgeController` with GET `/badges/:userId`.
  - Wired into `RewardsModule`.
- Tests
  - E2E tests verifying empty and non-empty responses.

### Endpoint
- GET `/badges/:userId`
  - 200 OK: `[ { id, badge, awardedAt }, ... ]` or `[]`

### Acceptance Criteria
- [x] Endpoint returns badges for given user
- [x] Empty array if none awarded

### Tests
- [x] Added `test/badges.e2e-spec.ts`
- [x] All tests passing locally (`npm run test:e2e`)

### Notes
- Uses SQLite (`swaptrade.db`) via TypeORM.
- No breaking changes.

### Issue Link
Closes #42