### PR TITLE
Add metrics tracking with Prometheus and Grafana integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,35 @@ services:
       - redis-data:/data
     restart: unless-stopped
 
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: app-prometheus
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: app-grafana
+    ports:
+      - '3001:3000'
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
 volumes:
   redis-data:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/grafana/dashboards/swaptrade-dashboard.json
+++ b/monitoring/grafana/dashboards/swaptrade-dashboard.json
@@ -1,0 +1,83 @@
+{
+  "id": null,
+  "title": "SwapTrade Performance",
+  "tags": ["swaptrade", "performance"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "HTTP Request Rate",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (route, method) (rate(http_requests_total[1m]))",
+          "legendFormat": "{{method}} {{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP P95 Latency (s)",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, route, method) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{method}} {{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Hit Ratio",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "cache_hit_ratio",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Requests",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(cache_requests_total[1m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "DB Slow Query Rate",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "sum by (operation) (rate(db_query_slow_total[5m]))",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "DB Slow Query P95 (s)",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(db_query_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+dashboards:
+  - name: SwapTrade Performance
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'swaptrade-backend'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['host.docker.internal:3000']

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,7 +244,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2354,7 +2353,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2539,7 +2537,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -2599,7 +2596,6 @@
       "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2673,7 +2669,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.6.tgz",
       "integrity": "sha512-HErwPmKnk+loTq8qzu1up+k7FC6Kqa8x6lJ4cDw77KnTxLzsCaPt+jBvOq6UfICmfqcqCCf3dKXg+aObQp+kIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -3028,7 +3023,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -3315,7 +3309,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3460,7 +3453,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3644,7 +3636,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -4334,7 +4325,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4424,7 +4414,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4915,7 +4904,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4988,7 +4976,6 @@
       "resolved": "https://registry.npmjs.org/bull/-/bull-4.16.5.tgz",
       "integrity": "sha512-lDsx2BzkKe7gkCYiT5Acj02DpTwDznl/VNN7Psn7M3USPG7Vs/BaClZJJTAG+ufAR9++N1/NiUTdaFBWDIl5TQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cron-parser": "^4.9.0",
         "get-port": "^5.1.1",
@@ -5134,7 +5121,6 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -5280,7 +5266,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5337,15 +5322,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6255,7 +6238,6 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6317,7 +6299,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7959,7 +7940,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8932,7 +8912,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -10505,7 +10484,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11957,7 +11935,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12294,7 +12271,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12467,7 +12443,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.27.tgz",
       "integrity": "sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -12698,7 +12673,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13077,6 +13051,7 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -13095,6 +13070,7 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -13108,6 +13084,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -13122,6 +13099,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -13131,7 +13109,8 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -13139,6 +13118,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -13149,6 +13129,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -13162,6 +13143,7 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "opossum": "^8.5.0",
     "p-limit": "^5.0.0",
     "p-retry": "^6.2.0",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",

--- a/src/common/services/cache-statistics.service.ts
+++ b/src/common/services/cache-statistics.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { MetricsService } from '../../metrics/metrics.service';
 
 export interface CacheStatistics {
   hits: number;
@@ -28,6 +29,8 @@ export class CacheStatisticsService {
     lastUpdated: new Date(),
   };
 
+  constructor(@Optional() private readonly metricsService?: MetricsService) {}
+
   /**
    * Record a cache hit
    */
@@ -36,6 +39,7 @@ export class CacheStatisticsService {
     this.stats.totalRequests++;
     this.updateKeyStats(key, 'hits');
     this.updateHitRatio();
+    this.metricsService?.recordCacheHit();
   }
 
   /**
@@ -46,6 +50,7 @@ export class CacheStatisticsService {
     this.stats.totalRequests++;
     this.updateKeyStats(key, 'misses');
     this.updateHitRatio();
+    this.metricsService?.recordCacheMiss();
   }
 
   /**
@@ -56,6 +61,7 @@ export class CacheStatisticsService {
     this.stats.errorsByType[errorType] =
       (this.stats.errorsByType[errorType] || 0) + 1;
     this.updateKeyStats(key, 'errors');
+    this.metricsService?.recordCacheError();
   }
 
   /**
@@ -67,6 +73,7 @@ export class CacheStatisticsService {
       this.stats.keyStats[key].hits = 0;
       this.stats.keyStats[key].misses = 0;
     }
+    this.metricsService?.recordCacheEviction();
   }
 
   /**

--- a/src/metrics/metrics.controller.ts
+++ b/src/metrics/metrics.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import { MetricsService } from './metrics.service';
+
+@Controller()
+export class MetricsController {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  @Get('metrics')
+  async getMetrics(@Res({ passthrough: true }) response: Response): Promise<string> {
+    response.setHeader('Content-Type', this.metricsService.getContentType());
+    return this.metricsService.getMetrics();
+  }
+}

--- a/src/metrics/metrics.interceptor.ts
+++ b/src/metrics/metrics.interceptor.ts
@@ -1,0 +1,33 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { MetricsService } from './metrics.service';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const response = http.getResponse();
+    const startTime = process.hrtime.bigint();
+
+    return next.handle().pipe(
+      finalize(() => {
+        const durationNs = process.hrtime.bigint() - startTime;
+        const durationSeconds = Number(durationNs) / 1e9;
+        const method = request?.method || 'UNKNOWN';
+        const route = request?.route?.path || request?.path || 'UNKNOWN';
+        const status = response?.statusCode || 500;
+
+        this.metricsService.recordHttpRequest(method, route, status, durationSeconds);
+      }),
+    );
+  }
+}

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,0 +1,12 @@
+import { Global, Module } from '@nestjs/common';
+import { MetricsService } from './metrics.service';
+import { MetricsController } from './metrics.controller';
+import { MetricsInterceptor } from './metrics.interceptor';
+
+@Global()
+@Module({
+  providers: [MetricsService, MetricsInterceptor],
+  controllers: [MetricsController],
+  exports: [MetricsService, MetricsInterceptor],
+})
+export class MetricsModule {}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+  collectDefaultMetrics,
+} from 'prom-client';
+
+@Injectable()
+export class MetricsService {
+  private readonly registry = new Registry();
+
+  readonly httpRequestsTotal = new Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method', 'route', 'status'],
+    registers: [this.registry],
+  });
+
+  readonly httpRequestDurationSeconds = new Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method', 'route', 'status'],
+    registers: [this.registry],
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  });
+
+  readonly dbQueryTotal = new Counter({
+    name: 'db_query_total',
+    help: 'Total number of database queries',
+    labelNames: ['operation', 'success'],
+    registers: [this.registry],
+  });
+
+  readonly dbQuerySlowTotal = new Counter({
+    name: 'db_query_slow_total',
+    help: 'Total number of slow database queries',
+    labelNames: ['operation'],
+    registers: [this.registry],
+  });
+
+  readonly dbQueryDurationSeconds = new Histogram({
+    name: 'db_query_duration_seconds',
+    help: 'Database query duration in seconds (slow queries)',
+    labelNames: ['operation'],
+    registers: [this.registry],
+    buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  });
+
+  readonly cacheRequestsTotal = new Counter({
+    name: 'cache_requests_total',
+    help: 'Total number of cache requests',
+    labelNames: ['result'],
+    registers: [this.registry],
+  });
+
+  readonly cacheHitRatio = new Gauge({
+    name: 'cache_hit_ratio',
+    help: 'Cache hit ratio (hits / (hits + misses))',
+    registers: [this.registry],
+  });
+
+  private cacheHits = 0;
+  private cacheMisses = 0;
+
+  constructor() {
+    collectDefaultMetrics({ register: this.registry });
+  }
+
+  getContentType(): string {
+    return this.registry.contentType;
+  }
+
+  async getMetrics(): Promise<string> {
+    return this.registry.metrics();
+  }
+
+  recordHttpRequest(method: string, route: string, status: number, durationSeconds: number): void {
+    this.httpRequestsTotal.labels(method, route, status.toString()).inc();
+    this.httpRequestDurationSeconds.labels(method, route, status.toString()).observe(durationSeconds);
+  }
+
+  recordDbQuery(operation: string, success: boolean): void {
+    this.dbQueryTotal.labels(operation, success ? 'true' : 'false').inc();
+  }
+
+  recordSlowDbQuery(operation: string, durationMs: number): void {
+    this.dbQuerySlowTotal.labels(operation).inc();
+    this.dbQueryDurationSeconds.labels(operation).observe(durationMs / 1000);
+  }
+
+  recordCacheHit(): void {
+    this.cacheHits += 1;
+    this.cacheRequestsTotal.labels('hit').inc();
+    this.updateCacheHitRatio();
+  }
+
+  recordCacheMiss(): void {
+    this.cacheMisses += 1;
+    this.cacheRequestsTotal.labels('miss').inc();
+    this.updateCacheHitRatio();
+  }
+
+  recordCacheError(): void {
+    this.cacheRequestsTotal.labels('error').inc();
+  }
+
+  recordCacheEviction(): void {
+    this.cacheRequestsTotal.labels('eviction').inc();
+  }
+
+  private updateCacheHitRatio(): void {
+    const total = this.cacheHits + this.cacheMisses;
+    const ratio = total > 0 ? this.cacheHits / total : 0;
+    this.cacheHitRatio.set(ratio);
+  }
+}

--- a/src/metrics/typeorm-logger.ts
+++ b/src/metrics/typeorm-logger.ts
@@ -1,0 +1,62 @@
+import type { Logger as TypeOrmLogger, QueryRunner } from 'typeorm';
+import { MetricsService } from './metrics.service';
+
+export class MetricsTypeOrmLogger implements TypeOrmLogger {
+  constructor(private readonly metricsService: MetricsService) {}
+
+  logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner): void {
+    const operation = this.getOperation(query);
+    this.metricsService.recordDbQuery(operation, true);
+  }
+
+  logQueryError(
+    error: string | Error,
+    query: string,
+    parameters?: any[],
+    queryRunner?: QueryRunner,
+  ): void {
+    const operation = this.getOperation(query);
+    this.metricsService.recordDbQuery(operation, false);
+  }
+
+  logQuerySlow(
+    time: number,
+    query: string,
+    parameters?: any[],
+    queryRunner?: QueryRunner,
+  ): void {
+    const operation = this.getOperation(query);
+    this.metricsService.recordSlowDbQuery(operation, time);
+  }
+
+  logSchemaBuild(message: string, queryRunner?: QueryRunner): void {
+    return;
+  }
+
+  logMigration(message: string, queryRunner?: QueryRunner): void {
+    return;
+  }
+
+  log(level: 'log' | 'info' | 'warn', message: any, queryRunner?: QueryRunner): void {
+    return;
+  }
+
+  private getOperation(query: string): string {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return 'unknown';
+    }
+    const operation = trimmed.split(' ')[0].toLowerCase();
+    switch (operation) {
+      case 'select':
+      case 'insert':
+      case 'update':
+      case 'delete':
+      case 'create':
+      case 'drop':
+        return operation;
+      default:
+        return 'other';
+    }
+  }
+}


### PR DESCRIPTION
this closes #106
- Implemented MetricsModule, MetricsService, and MetricsInterceptor for tracking HTTP requests, database queries, and cache statistics.
- Added Prometheus and Grafana services to docker-compose for monitoring.
- Created Grafana dashboard configuration for visualizing performance metrics.
- Updated application to record metrics for cache hits, misses, and database query performance.