### PR TITLE
feat:#165 Implement Customizable Notification & Alert System

### DIFF
--- a/docs/NOTIFICATION_ALERT_SYSTEM.md
+++ b/docs/NOTIFICATION_ALERT_SYSTEM.md
@@ -1,0 +1,282 @@
+# Notification & Alert System
+
+## Overview
+
+The notification and alert system allows users to configure custom alerts for trading events (price movements, volume thresholds, portfolio changes) and receive notifications through multiple channels: email, SMS, push (FCM), and in-app.
+
+---
+
+## Environment Variables
+
+Add the following to your `.env` file:
+
+```env
+# Email (SMTP)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your@email.com
+SMTP_PASS=your-smtp-password
+SMTP_FROM=noreply@swaptrade.io
+APP_URL=http://localhost:3000
+
+# SMS (Twilio)
+TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+TWILIO_AUTH_TOKEN=your-twilio-auth-token
+TWILIO_FROM_NUMBER=+15551234567
+
+# Push Notifications (Firebase Cloud Messaging)
+PUSH_PROVIDER=fcm                            # set to 'fcm' to enable push
+FIREBASE_SERVER_KEY=AAAAxxxxxxxx...          # Firebase legacy server key
+```
+
+---
+
+## Alert System
+
+### Alert Types
+
+| Type | Trigger condition |
+|---|---|
+| `PRICE` | Asset spot price crosses a threshold |
+| `VOLUME` | Asset 24-hour volume crosses a threshold |
+| `PORTFOLIO_CHANGE` | Portfolio total value changes by an amount or percentage |
+
+### Operators
+
+`GT` (>), `LT` (<), `GTE` (>=), `LTE` (<=)
+
+### Alert Channels
+
+`EMAIL`, `SMS`, `IN_APP`, `PUSH`
+
+---
+
+## Alert API Endpoints
+
+### Create Alert
+
+```http
+POST /alerts/:userId
+Content-Type: application/json
+
+{
+  "name": "BTC above $50k",
+  "type": "PRICE",
+  "asset": "BTCUSDT",
+  "operator": "GT",
+  "threshold": 50000,
+  "channels": ["EMAIL", "IN_APP"],
+  "cooldownMinutes": 60
+}
+```
+
+**Portfolio change alert example:**
+```json
+{
+  "name": "Portfolio drops 5%",
+  "type": "PORTFOLIO_CHANGE",
+  "changeType": "PERCENTAGE",
+  "changeThreshold": 5.0,
+  "channels": ["SMS", "IN_APP"],
+  "cooldownMinutes": 120
+}
+```
+
+### List Alerts
+
+```http
+GET /alerts/:userId
+```
+
+### Get Alert
+
+```http
+GET /alerts/:userId/:alertId
+```
+
+### Update Alert
+
+```http
+PATCH /alerts/:userId/:alertId
+Content-Type: application/json
+
+{
+  "threshold": 55000,
+  "cooldownMinutes": 30
+}
+```
+
+### Delete Alert
+
+```http
+DELETE /alerts/:userId/:alertId
+```
+Returns `204 No Content`.
+
+### Pause / Resume Alert
+
+```http
+POST /alerts/:userId/:alertId/pause
+POST /alerts/:userId/:alertId/resume
+```
+
+### Alert Trigger History
+
+```http
+GET /alerts/:userId/:alertId/history?limit=50&offset=0
+```
+
+Returns the list of times this alert fired, with the trigger value and notification ID.
+
+---
+
+## Alert Evaluation
+
+Alerts are evaluated automatically:
+
+- **PRICE / VOLUME alerts**: Evaluated on every market data update received from the Binance/Coinbase WebSocket feeds.
+- **PORTFOLIO_CHANGE alerts**: Evaluated when a `user.portfolio.updated` event is emitted (e.g., after a trade executes).
+
+When an alert condition is met and the cooldown has expired, a job is enqueued in the `alerts` Bull queue. The `AlertProcessor` then delivers the notification via the selected channels.
+
+**Cooldown**: After firing, an alert enters `TRIGGERED` status. It won't fire again until `cooldownMinutes` has elapsed. Use `POST /alerts/:userId/:alertId/resume` to manually re-activate it.
+
+**Portfolio baseline**: On first evaluation, the current portfolio value is stored as the `referenceValue`. Subsequent evaluations compare against this baseline. The baseline resets after each trigger.
+
+---
+
+## Notification Preferences API
+
+### Per-channel preferences (granular control)
+
+Get or update which types of notifications are enabled per channel:
+
+```http
+GET  /notification/preferences/:userId
+PATCH /notification/preferences/:userId
+
+# PATCH body — array of preference objects:
+[
+  { "type": "ALERT", "channel": "EMAIL", "enabled": true },
+  { "type": "ORDER_FILLED", "channel": "SMS", "enabled": false }
+]
+```
+
+Each preference row also tracks `dailyLimit` and `sentToday` to prevent spam.
+
+### High-level notification settings
+
+Get or update frequency, channels, and notification type toggles:
+
+```http
+GET   /notification/settings/:userId
+PATCH /notification/settings/:userId
+
+# PATCH body:
+{
+  "frequency": "INSTANT",           // INSTANT | HOURLY | DAILY
+  "channels": ["EMAIL", "IN_APP"],  // default delivery channels
+  "tradeNotifications": true,
+  "balanceNotifications": true,
+  "milestoneNotifications": false
+}
+```
+
+### Unsubscribe via token
+
+```http
+GET /notification/unsubscribe?token=<unsubscribeToken>
+```
+
+Disables the preference row associated with the token. Unsubscribe tokens are included automatically in email delivery footers.
+
+---
+
+## Notification Delivery API
+
+### Send a notification (internal/admin use)
+
+```http
+POST /notification
+Content-Type: application/json
+
+{
+  "userId": 1,
+  "type": "ORDER_FILLED",
+  "message": "Your order for 0.5 BTC has been filled.",
+  "subject": "Order Filled",
+  "channels": ["EMAIL", "IN_APP"]
+}
+```
+
+### List user notifications
+
+```http
+GET /notification/:userId?limit=20&offset=0&status=SENT
+```
+
+`status` filter: `SENT`, `READ`, `FAILED`
+
+### Mark notification as read
+
+```http
+POST /notification/:notificationId/read
+Content-Type: application/json
+
+{ "userId": 1 }
+```
+
+---
+
+## Notification Channels
+
+### Email
+- Delivered via SMTP (nodemailer).
+- Requires `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`.
+- Each email includes an unsubscribe link.
+- The `metadata.email` field in the notification must contain the recipient address.
+
+### SMS
+- Delivered via Twilio.
+- Requires `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_FROM_NUMBER`.
+- The `metadata.phone` field must contain the E.164 phone number (e.g. `+15551234567`).
+
+### In-App
+- The notification record is stored in the database and returned by `GET /notification/:userId`.
+- No additional transport needed. Clients can poll this endpoint or listen for WebSocket events.
+
+### Push (FCM)
+- Delivered via Firebase Cloud Messaging.
+- Requires `PUSH_PROVIDER=fcm` and `FIREBASE_SERVER_KEY`.
+- The `metadata.deviceToken` field must contain the FCM registration token.
+- If `PUSH_PROVIDER` is not set to `fcm`, push delivery is skipped with a warning log.
+
+---
+
+## Notification Templates
+
+Templates use Handlebars syntax and are stored in the `notification_templates` table.
+
+| Field | Description |
+|---|---|
+| `key` | Unique template key (e.g. `order_filled`) |
+| `name` | Human-readable name |
+| `channel` | `EMAIL`, `SMS`, `IN_APP`, or `PUSH` |
+| `subject` | Email subject line (Handlebars) |
+| `body` | Notification body (Handlebars) |
+
+Pass `templateKey` in `SendNotificationDto` to use a template. The `metadata` object is available as template context.
+
+Example template body:
+```
+Your order for {{amount}} {{asset}} was filled at {{price}}.
+```
+
+---
+
+## Reliability
+
+- All notifications are processed via a Bull job queue with exponential backoff (up to 5 retry attempts).
+- Failed deliveries are tracked in `notification_jobs` with the last error message.
+- Daily limits per channel/type are enforced via `NotificationPreference.dailyLimit`.
+- Alert cooldowns prevent duplicate notifications within a configurable time window.

--- a/src/alerts/alert-evaluation.service.ts
+++ b/src/alerts/alert-evaluation.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { InjectQueue } from '@nestjs/bull';
+import type { Queue } from 'bull';
+import {
+  AlertRule,
+  AlertType,
+  AlertOperator,
+  PortfolioChangeType,
+} from './entities/alert-rule.entity';
+import { AlertService } from './alert.service';
+import { NotificationChannel } from '../notification/entities/notification.entity';
+import type {
+  MarketDataUpdate,
+  PortfolioUpdate,
+} from '../websocket/interfaces/websocket.interfaces';
+import { QueueName } from '../queue/queue.constants';
+
+export interface AlertFireJobData {
+  alertId: number;
+  userId: number;
+  triggerValue: number;
+  message: string;
+  channels: NotificationChannel[];
+  alertName: string;
+}
+
+@Injectable()
+export class AlertEvaluationService {
+  private readonly logger = new Logger(AlertEvaluationService.name);
+
+  constructor(
+    private readonly alertService: AlertService,
+    @InjectQueue(QueueName.ALERTS)
+    private readonly alertsQueue: Queue<AlertFireJobData>,
+  ) {}
+
+  @OnEvent('market.data.updated', { async: true })
+  async handleMarketDataUpdated(data: MarketDataUpdate): Promise<void> {
+    try {
+      const rules = await this.alertService.findActiveRulesForAsset(data.asset, [
+        AlertType.PRICE,
+        AlertType.VOLUME,
+      ]);
+
+      for (const rule of rules) {
+        if (!this.isCooldownExpired(rule)) continue;
+
+        const currentValue =
+          rule.type === AlertType.PRICE ? data.price : data.volume24h;
+
+        if (this.evaluateCondition(currentValue, rule.operator!, rule.threshold!)) {
+          await this.enqueueAlertFiring(rule, currentValue);
+        }
+      }
+    } catch (error) {
+      this.logger.error('Error evaluating market.data.updated alerts:', error);
+    }
+  }
+
+  @OnEvent('user.portfolio.updated', { async: true })
+  async handlePortfolioUpdated(data: PortfolioUpdate): Promise<void> {
+    try {
+      const userId = Number(data.userId);
+      const rules = await this.alertService.findActivePortfolioRules(userId);
+
+      for (const rule of rules) {
+        if (!this.isCooldownExpired(rule)) continue;
+
+        if (rule.referenceValue === null || rule.referenceValue === undefined) {
+          await this.alertService.updateReferenceValue(rule.id, data.totalValue);
+          continue;
+        }
+
+        if (this.evaluatePortfolioCondition(rule, data.totalValue)) {
+          await this.enqueueAlertFiring(rule, data.totalValue);
+          await this.alertService.updateReferenceValue(rule.id, data.totalValue);
+        }
+      }
+    } catch (error) {
+      this.logger.error('Error evaluating user.portfolio.updated alerts:', error);
+    }
+  }
+
+  private evaluateCondition(
+    currentValue: number,
+    operator: AlertOperator,
+    threshold: number,
+  ): boolean {
+    switch (operator) {
+      case AlertOperator.GT:
+        return currentValue > threshold;
+      case AlertOperator.LT:
+        return currentValue < threshold;
+      case AlertOperator.GTE:
+        return currentValue >= threshold;
+      case AlertOperator.LTE:
+        return currentValue <= threshold;
+      default:
+        return false;
+    }
+  }
+
+  private evaluatePortfolioCondition(rule: AlertRule, currentValue: number): boolean {
+    const ref = Number(rule.referenceValue);
+    if (!ref || ref === 0) return false;
+
+    const changeThreshold = Number(rule.changeThreshold) ?? 0;
+
+    const change =
+      rule.changeType === PortfolioChangeType.PERCENTAGE
+        ? Math.abs((currentValue - ref) / ref) * 100
+        : Math.abs(currentValue - ref);
+
+    return change >= changeThreshold;
+  }
+
+  private isCooldownExpired(rule: AlertRule): boolean {
+    if (!rule.lastTriggeredAt) return true;
+    const cooldownMs = rule.cooldownMinutes * 60 * 1000;
+    return Date.now() - new Date(rule.lastTriggeredAt).getTime() >= cooldownMs;
+  }
+
+  private async enqueueAlertFiring(rule: AlertRule, triggerValue: number): Promise<void> {
+    const message = this.buildAlertMessage(rule, triggerValue);
+
+    await this.alertsQueue.add(
+      'fire-alert',
+      {
+        alertId: rule.id,
+        userId: rule.userId,
+        triggerValue,
+        message,
+        channels: rule.channels,
+        alertName: rule.name,
+      },
+      {
+        priority: 1,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 500 },
+      },
+    );
+
+    this.logger.log(
+      `Alert queued: alertId=${rule.id} userId=${rule.userId} value=${triggerValue}`,
+    );
+  }
+
+  private buildAlertMessage(rule: AlertRule, triggerValue: number): string {
+    switch (rule.type) {
+      case AlertType.PRICE:
+        return `Price alert "${rule.name}": ${rule.asset} is now ${triggerValue} (condition: ${rule.operator} ${rule.threshold})`;
+      case AlertType.VOLUME:
+        return `Volume alert "${rule.name}": ${rule.asset} 24h volume is ${triggerValue} (condition: ${rule.operator} ${rule.threshold})`;
+      case AlertType.PORTFOLIO_CHANGE:
+        return `Portfolio alert "${rule.name}": your portfolio value is now ${triggerValue} (change threshold: ${rule.changeThreshold}${rule.changeType === PortfolioChangeType.PERCENTAGE ? '%' : ''})`;
+      default:
+        return `Alert "${rule.name}" triggered: current value is ${triggerValue}`;
+    }
+  }
+}

--- a/src/alerts/alert.controller.ts
+++ b/src/alerts/alert.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  ParseIntPipe,
+  Query,
+  HttpCode,
+  HttpStatus,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { AlertService } from './alert.service';
+import { CreateAlertDto } from './dto/create-alert.dto';
+import { UpdateAlertDto } from './dto/update-alert.dto';
+
+@ApiTags('alerts')
+@ApiBearerAuth()
+@Controller('alerts')
+export class AlertController {
+  constructor(private readonly alertService: AlertService) {}
+
+  @Post(':userId')
+  @ApiOperation({ summary: 'Create a new alert rule for a user' })
+  @ApiResponse({ status: 201, description: 'Alert rule created successfully' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  createAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Body(new ValidationPipe({ whitelist: true, transform: true }))
+    dto: CreateAlertDto,
+  ) {
+    return this.alertService.createAlert(userId, dto);
+  }
+
+  @Get(':userId')
+  @ApiOperation({ summary: 'List all alert rules for a user' })
+  @ApiResponse({ status: 200, description: 'Array of alert rules' })
+  getAlerts(@Param('userId', ParseIntPipe) userId: number) {
+    return this.alertService.getAlerts(userId);
+  }
+
+  @Get(':userId/:alertId')
+  @ApiOperation({ summary: 'Get a specific alert rule' })
+  @ApiResponse({ status: 200, description: 'Alert rule' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  @ApiResponse({ status: 403, description: 'Forbidden — alert belongs to another user' })
+  getAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+  ) {
+    return this.alertService.getAlert(userId, alertId);
+  }
+
+  @Patch(':userId/:alertId')
+  @ApiOperation({ summary: 'Update an alert rule' })
+  @ApiResponse({ status: 200, description: 'Updated alert rule' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  updateAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+    @Body(new ValidationPipe({ whitelist: true, transform: true }))
+    dto: UpdateAlertDto,
+  ) {
+    return this.alertService.updateAlert(userId, alertId, dto);
+  }
+
+  @Delete(':userId/:alertId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete an alert rule' })
+  @ApiResponse({ status: 204, description: 'Alert deleted' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  deleteAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+  ) {
+    return this.alertService.deleteAlert(userId, alertId);
+  }
+
+  @Post(':userId/:alertId/pause')
+  @ApiOperation({ summary: 'Pause an active alert rule' })
+  @ApiResponse({ status: 200, description: 'Alert paused' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  pauseAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+  ) {
+    return this.alertService.pauseAlert(userId, alertId);
+  }
+
+  @Post(':userId/:alertId/resume')
+  @ApiOperation({ summary: 'Resume a paused alert rule' })
+  @ApiResponse({ status: 200, description: 'Alert resumed' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  resumeAlert(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+  ) {
+    return this.alertService.resumeAlert(userId, alertId);
+  }
+
+  @Get(':userId/:alertId/history')
+  @ApiOperation({ summary: 'Get trigger history for an alert' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Max results (default 50)' })
+  @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Pagination offset (default 0)' })
+  @ApiResponse({ status: 200, description: 'Trigger history events' })
+  @ApiResponse({ status: 404, description: 'Alert not found' })
+  getAlertHistory(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Param('alertId', ParseIntPipe) alertId: number,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    return this.alertService.getAlertHistory(
+      userId,
+      alertId,
+      limit ? parseInt(limit, 10) : 50,
+      offset ? parseInt(offset, 10) : 0,
+    );
+  }
+}

--- a/src/alerts/alert.module.ts
+++ b/src/alerts/alert.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { AlertRule } from './entities/alert-rule.entity';
+import { AlertTriggeredEvent } from './entities/alert-triggered-event.entity';
+import { AlertService } from './alert.service';
+import { AlertEvaluationService } from './alert-evaluation.service';
+import { AlertProcessor } from './alert.processor';
+import { AlertController } from './alert.controller';
+import { NotificationModule } from '../notification/notification.module';
+import { QueueName } from '../queue/queue.constants';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([AlertRule, AlertTriggeredEvent]),
+    BullModule.registerQueue({
+      name: QueueName.ALERTS,
+      defaultJobOptions: {
+        priority: 1,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 500 },
+        removeOnComplete: { age: 24 * 3600 },
+        removeOnFail: { age: 7 * 24 * 3600 },
+      },
+    }),
+    NotificationModule,
+  ],
+  controllers: [AlertController],
+  providers: [AlertService, AlertEvaluationService, AlertProcessor],
+  exports: [AlertService],
+})
+export class AlertModule {}

--- a/src/alerts/alert.processor.ts
+++ b/src/alerts/alert.processor.ts
@@ -1,0 +1,78 @@
+import {
+  Processor,
+  Process,
+  OnQueueActive,
+  OnQueueCompleted,
+  OnQueueFailed,
+} from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import type { Job } from 'bull';
+import { AlertService } from './alert.service';
+import { NotificationService } from '../notification/notification.service';
+import type { AlertFireJobData } from './alert-evaluation.service';
+import { AlertStatus } from './entities/alert-rule.entity';
+import { QueueName } from '../queue/queue.constants';
+
+@Processor(QueueName.ALERTS)
+export class AlertProcessor {
+  private readonly logger = new Logger(AlertProcessor.name);
+
+  constructor(
+    private readonly alertService: AlertService,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  @Process({ name: 'fire-alert', concurrency: 5 })
+  async fireAlert(job: Job<AlertFireJobData>): Promise<void> {
+    const { alertId, userId, triggerValue, message, channels, alertName } = job.data;
+
+    this.logger.log(`Processing alert fire: alertId=${alertId} userId=${userId}`);
+    await job.progress(10);
+
+    const rules = await this.alertService.getAlerts(userId);
+    const rule = rules.find((r) => r.id === alertId);
+
+    if (!rule || rule.status !== AlertStatus.ACTIVE) {
+      this.logger.warn(
+        `Alert ${alertId} is no longer active (status=${rule?.status ?? 'not found'}), skipping.`,
+      );
+      return;
+    }
+
+    await job.progress(30);
+
+    const notification = await this.notificationService.sendAlert({
+      userId,
+      message,
+      subject: alertName,
+      channels,
+      type: 'ALERT',
+      metadata: { alertId, triggerValue },
+    });
+
+    await job.progress(70);
+
+    await this.alertService.recordTrigger(rule, triggerValue, notification?.id ?? null);
+
+    await job.progress(100);
+    this.logger.log(`Alert fired successfully: alertId=${alertId}`);
+  }
+
+  @OnQueueActive()
+  onActive(job: Job<AlertFireJobData>): void {
+    this.logger.debug(`Alert job ${job.id} started for alertId=${job.data.alertId}`);
+  }
+
+  @OnQueueCompleted()
+  onCompleted(job: Job<AlertFireJobData>): void {
+    this.logger.log(`Alert job ${job.id} completed for alertId=${job.data.alertId}`);
+  }
+
+  @OnQueueFailed()
+  onFailed(job: Job<AlertFireJobData>, error: Error): void {
+    this.logger.error(
+      `Alert job ${job.id} failed for alertId=${job.data.alertId}: ${error.message}`,
+      error.stack,
+    );
+  }
+}

--- a/src/alerts/alert.service.ts
+++ b/src/alerts/alert.service.ts
@@ -1,0 +1,152 @@
+import { Injectable, ForbiddenException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AlertRule, AlertStatus } from './entities/alert-rule.entity';
+import { AlertTriggeredEvent } from './entities/alert-triggered-event.entity';
+import { CreateAlertDto } from './dto/create-alert.dto';
+import { UpdateAlertDto } from './dto/update-alert.dto';
+import { ResourceNotFoundException } from '../common/exceptions';
+
+@Injectable()
+export class AlertService {
+  private readonly logger = new Logger(AlertService.name);
+
+  constructor(
+    @InjectRepository(AlertRule)
+    private readonly alertRepo: Repository<AlertRule>,
+    @InjectRepository(AlertTriggeredEvent)
+    private readonly triggerEventRepo: Repository<AlertTriggeredEvent>,
+  ) {}
+
+  async createAlert(userId: number, dto: CreateAlertDto): Promise<AlertRule> {
+    const rule = this.alertRepo.create({
+      userId,
+      name: dto.name,
+      type: dto.type,
+      status: AlertStatus.ACTIVE,
+      asset: dto.asset ?? null,
+      operator: dto.operator ?? null,
+      threshold: dto.threshold ?? null,
+      changeType: dto.changeType ?? null,
+      changeThreshold: dto.changeThreshold ?? null,
+      referenceValue: null,
+      channels: dto.channels,
+      cooldownMinutes: dto.cooldownMinutes ?? 60,
+      lastTriggeredAt: null,
+      triggerCount: 0,
+    });
+    const saved = await this.alertRepo.save(rule);
+    this.logger.log(`Alert created: id=${saved.id} userId=${userId} type=${dto.type}`);
+    return saved;
+  }
+
+  async getAlerts(userId: number): Promise<AlertRule[]> {
+    return this.alertRepo.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getAlert(userId: number, alertId: number): Promise<AlertRule> {
+    const rule = await this.alertRepo.findOne({ where: { id: alertId } });
+    if (!rule) {
+      throw new ResourceNotFoundException('AlertRule', alertId);
+    }
+    if (rule.userId !== userId) {
+      throw new ForbiddenException('You do not own this alert');
+    }
+    return rule;
+  }
+
+  async updateAlert(
+    userId: number,
+    alertId: number,
+    dto: UpdateAlertDto,
+  ): Promise<AlertRule> {
+    const rule = await this.getAlert(userId, alertId);
+    Object.assign(rule, dto);
+    return this.alertRepo.save(rule);
+  }
+
+  async deleteAlert(userId: number, alertId: number): Promise<void> {
+    const rule = await this.getAlert(userId, alertId);
+    await this.alertRepo.remove(rule);
+    this.logger.log(`Alert deleted: id=${alertId} userId=${userId}`);
+  }
+
+  async pauseAlert(userId: number, alertId: number): Promise<AlertRule> {
+    const rule = await this.getAlert(userId, alertId);
+    rule.status = AlertStatus.PAUSED;
+    return this.alertRepo.save(rule);
+  }
+
+  async resumeAlert(userId: number, alertId: number): Promise<AlertRule> {
+    const rule = await this.getAlert(userId, alertId);
+    rule.status = AlertStatus.ACTIVE;
+    return this.alertRepo.save(rule);
+  }
+
+  async getAlertHistory(
+    userId: number,
+    alertId: number,
+    limit = 50,
+    offset = 0,
+  ): Promise<AlertTriggeredEvent[]> {
+    await this.getAlert(userId, alertId);
+    return this.triggerEventRepo.find({
+      where: { alertId, userId },
+      order: { triggeredAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+  }
+
+  async recordTrigger(
+    rule: AlertRule,
+    triggerValue: number,
+    notificationId: number | null,
+  ): Promise<void> {
+    const event = this.triggerEventRepo.create({
+      alertId: rule.id,
+      userId: rule.userId,
+      triggerValue,
+      notificationId,
+      channel: rule.channels[0] ?? null,
+    });
+    await this.triggerEventRepo.save(event);
+
+    rule.lastTriggeredAt = new Date();
+    rule.triggerCount += 1;
+    rule.status = AlertStatus.TRIGGERED;
+    await this.alertRepo.save(rule);
+
+    this.logger.log(
+      `Alert triggered: id=${rule.id} userId=${rule.userId} value=${triggerValue}`,
+    );
+  }
+
+  async findActiveRulesForAsset(
+    asset: string,
+    types: string[],
+  ): Promise<AlertRule[]> {
+    return this.alertRepo
+      .createQueryBuilder('rule')
+      .where('rule.asset = :asset', { asset })
+      .andWhere('rule.type IN (:...types)', { types })
+      .andWhere('rule.status = :status', { status: AlertStatus.ACTIVE })
+      .getMany();
+  }
+
+  async findActivePortfolioRules(userId: number): Promise<AlertRule[]> {
+    return this.alertRepo
+      .createQueryBuilder('rule')
+      .where('rule.userId = :userId', { userId })
+      .andWhere('rule.type = :type', { type: 'PORTFOLIO_CHANGE' })
+      .andWhere('rule.status = :status', { status: AlertStatus.ACTIVE })
+      .getMany();
+  }
+
+  async updateReferenceValue(alertId: number, value: number): Promise<void> {
+    await this.alertRepo.update(alertId, { referenceValue: value });
+  }
+}

--- a/src/alerts/dto/create-alert.dto.ts
+++ b/src/alerts/dto/create-alert.dto.ts
@@ -1,0 +1,97 @@
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsArray,
+  IsNumber,
+  IsInt,
+  Min,
+  Max,
+  ValidateIf,
+  Length,
+  ArrayNotEmpty,
+  ArrayMaxSize,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  AlertType,
+  AlertOperator,
+  PortfolioChangeType,
+} from '../entities/alert-rule.entity';
+import { NotificationChannel } from '../../notification/entities/notification.entity';
+
+export class CreateAlertDto {
+  @ApiProperty({ example: 'BTC price alert', description: 'Human-readable alert name' })
+  @IsString()
+  @Length(1, 100)
+  name: string;
+
+  @ApiProperty({ enum: AlertType, description: 'Type of alert condition' })
+  @IsEnum(AlertType)
+  type: AlertType;
+
+  @ApiPropertyOptional({
+    example: 'BTCUSDT',
+    description: 'Asset symbol (required for PRICE and VOLUME alerts)',
+  })
+  @ValidateIf((o) => o.type === AlertType.PRICE || o.type === AlertType.VOLUME)
+  @IsString()
+  @Length(1, 20)
+  asset?: string;
+
+  @ApiPropertyOptional({
+    enum: AlertOperator,
+    description: 'Comparison operator (required for PRICE and VOLUME alerts)',
+  })
+  @ValidateIf((o) => o.type === AlertType.PRICE || o.type === AlertType.VOLUME)
+  @IsEnum(AlertOperator)
+  operator?: AlertOperator;
+
+  @ApiPropertyOptional({
+    example: 50000,
+    description: 'Threshold value to compare against (required for PRICE and VOLUME alerts)',
+  })
+  @ValidateIf((o) => o.type === AlertType.PRICE || o.type === AlertType.VOLUME)
+  @IsNumber()
+  @Min(0)
+  threshold?: number;
+
+  @ApiPropertyOptional({
+    enum: PortfolioChangeType,
+    description: 'How to measure portfolio change (required for PORTFOLIO_CHANGE alerts)',
+  })
+  @ValidateIf((o) => o.type === AlertType.PORTFOLIO_CHANGE)
+  @IsEnum(PortfolioChangeType)
+  changeType?: PortfolioChangeType;
+
+  @ApiPropertyOptional({
+    example: 5.0,
+    description: 'Change threshold e.g. 5 for 5% (required for PORTFOLIO_CHANGE alerts)',
+  })
+  @ValidateIf((o) => o.type === AlertType.PORTFOLIO_CHANGE)
+  @IsNumber()
+  @Min(0)
+  changeThreshold?: number;
+
+  @ApiProperty({
+    enum: NotificationChannel,
+    isArray: true,
+    example: ['EMAIL', 'IN_APP'],
+    description: 'Delivery channels for this alert',
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(4)
+  @IsEnum(NotificationChannel, { each: true })
+  channels: NotificationChannel[];
+
+  @ApiPropertyOptional({
+    example: 60,
+    description: 'Minimum minutes before this alert can fire again (1 to 10080)',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10080)
+  cooldownMinutes?: number;
+}

--- a/src/alerts/dto/update-alert.dto.ts
+++ b/src/alerts/dto/update-alert.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAlertDto } from './create-alert.dto';
+
+export class UpdateAlertDto extends PartialType(CreateAlertDto) {}

--- a/src/alerts/entities/alert-rule.entity.ts
+++ b/src/alerts/entities/alert-rule.entity.ts
@@ -1,0 +1,90 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { NotificationChannel } from '../../notification/entities/notification.entity';
+
+export enum AlertType {
+  PRICE = 'PRICE',
+  VOLUME = 'VOLUME',
+  PORTFOLIO_CHANGE = 'PORTFOLIO_CHANGE',
+}
+
+export enum AlertStatus {
+  ACTIVE = 'ACTIVE',
+  PAUSED = 'PAUSED',
+  TRIGGERED = 'TRIGGERED',
+}
+
+export enum AlertOperator {
+  GT = 'GT',
+  LT = 'LT',
+  GTE = 'GTE',
+  LTE = 'LTE',
+}
+
+export enum PortfolioChangeType {
+  PERCENTAGE = 'PERCENTAGE',
+  ABSOLUTE = 'ABSOLUTE',
+}
+
+@Entity('alert_rules')
+@Index(['userId', 'status'])
+@Index(['asset', 'type', 'status'])
+export class AlertRule {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @Index()
+  userId: number;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ type: 'varchar' })
+  type: AlertType;
+
+  @Column({ type: 'varchar', default: AlertStatus.ACTIVE })
+  status: AlertStatus;
+
+  @Column({ nullable: true, length: 20 })
+  asset: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  operator: AlertOperator | null;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: true })
+  threshold: number | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  changeType: PortfolioChangeType | null;
+
+  @Column({ type: 'decimal', precision: 10, scale: 4, nullable: true })
+  changeThreshold: number | null;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, nullable: true })
+  referenceValue: number | null;
+
+  @Column({ type: 'simple-array' })
+  channels: NotificationChannel[];
+
+  @Column({ type: 'int', default: 60 })
+  cooldownMinutes: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  lastTriggeredAt: Date | null;
+
+  @Column({ type: 'int', default: 0 })
+  triggerCount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/alerts/entities/alert-triggered-event.entity.ts
+++ b/src/alerts/entities/alert-triggered-event.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { NotificationChannel } from '../../notification/entities/notification.entity';
+
+@Entity('alert_triggered_events')
+@Index(['alertId', 'triggeredAt'])
+@Index(['userId', 'triggeredAt'])
+export class AlertTriggeredEvent {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  @Index()
+  alertId: number;
+
+  @Column()
+  @Index()
+  userId: number;
+
+  @CreateDateColumn()
+  triggeredAt: Date;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  triggerValue: number;
+
+  @Column({ nullable: true })
+  notificationId: number | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  channel: NotificationChannel | null;
+
+  @Column({ type: 'text', nullable: true })
+  note: string | null;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -20,6 +20,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { TutorialModule } from './tutorial/tutorial.module';
 import { GqlAppModule } from './graphql/graphql.module';
 import { AuditLogModule } from './audit-log/audit-log.module';
+import { AlertModule } from './alerts/alert.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { AuditLogModule } from './audit-log/audit-log.module';
     MarketDataModule,
     ExportModule,
     AuditLogModule,
+    AlertModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/market-data/market-data.service.ts
+++ b/src/market-data/market-data.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MarketData } from '../trading/entities/market-data.entity';
 import { MarketDataProvider, PriceUpdate, MarketDataConfig } from './interfaces/market-provider.interface';
 import { BinanceProvider } from './providers/binance-provider';
@@ -8,6 +9,7 @@ import { CoinbaseProvider } from './providers/coinbase-provider';
 import { MarketDataValidatorService } from './services/market-data-validator.service';
 import { CacheService } from '../common/services/cache.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import type { MarketDataUpdate } from '../websocket/interfaces/websocket.interfaces';
 
 @Injectable()
 export class MarketDataService implements OnModuleInit, OnModuleDestroy {
@@ -24,6 +26,7 @@ export class MarketDataService implements OnModuleInit, OnModuleDestroy {
     private readonly marketDataRepository: Repository<MarketData>,
     private readonly validatorService: MarketDataValidatorService,
     private readonly cacheService: CacheService,
+    private readonly eventEmitter: EventEmitter2,
   ) {
     this.config = this.loadConfig();
   }
@@ -147,6 +150,16 @@ export class MarketDataService implements OnModuleInit, OnModuleDestroy {
 
       await this.updateMarketData(sanitizedData);
       await this.updateCache(data as any);
+
+      this.eventEmitter.emit('market.data.updated', {
+        asset: sanitizedData.symbol,
+        price: sanitizedData.price,
+        volume24h: (data as any).volume ?? 0,
+        change24h: 0,
+        high24h: 0,
+        low24h: 0,
+        timestamp: new Date().toISOString(),
+      } as MarketDataUpdate);
 
     } catch (error) {
       this.logger.error(`Error handling price update for ${data.symbol}:`, error);

--- a/src/notification/dto/notification.dto.ts
+++ b/src/notification/dto/notification.dto.ts
@@ -1,7 +1,9 @@
 import { IsEnum, IsOptional, IsBoolean, IsArray, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { NotificationType } from '../entities/notification-event.entity';
-import { NotificationChannel, NotificationFrequency } from '../entities/user-notification-preferences.entity';
+import { NotificationChannel } from '../entities/notification.entity';
+import { NotificationFrequency } from '../entities/user-notification-preferences.entity';
 
 export class GetNotificationsDto {
   @IsOptional()
@@ -28,23 +30,28 @@ export class GetNotificationsDto {
 }
 
 export class UpdatePreferencesDto {
+  @ApiPropertyOptional({ enum: NotificationFrequency })
   @IsOptional()
   @IsEnum(NotificationFrequency)
   frequency?: NotificationFrequency;
 
+  @ApiPropertyOptional({ enum: NotificationChannel, isArray: true })
   @IsOptional()
   @IsArray()
   @IsEnum(NotificationChannel, { each: true })
   channels?: NotificationChannel[];
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   tradeNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   balanceNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   milestoneNotifications?: boolean;

--- a/src/notification/entities/user-notification-preferences.entity.ts
+++ b/src/notification/entities/user-notification-preferences.entity.ts
@@ -1,14 +1,16 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { NotificationChannel } from './notification.entity';
 
 export enum NotificationFrequency {
-  INSTANT = 'instant',
-  HOURLY = 'hourly',
-  DAILY = 'daily'
-}
-
-export enum NotificationChannel {
-  IN_APP = 'in-app',
-  EMAIL = 'email'
+  INSTANT = 'INSTANT',
+  HOURLY = 'HOURLY',
+  DAILY = 'DAILY',
 }
 
 @Entity('user_notification_preferences')
@@ -19,14 +21,10 @@ export class UserNotificationPreferences {
   @Column({ unique: true })
   userId: string;
 
-  @Column({
-    type: 'enum',
-    enum: NotificationFrequency,
-    default: NotificationFrequency.INSTANT
-  })
+  @Column({ type: 'varchar', default: NotificationFrequency.INSTANT })
   frequency: NotificationFrequency;
 
-  @Column('simple-array', { default: 'in-app,email' })
+  @Column({ type: 'simple-array', default: 'IN_APP,EMAIL' })
   channels: NotificationChannel[];
 
   @Column({ default: true })

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -2,46 +2,117 @@ import {
   Body,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   Patch,
   Post,
   Query,
+  ValidationPipe,
 } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { NotificationService } from './notification.service';
 import { SendNotificationDto } from './dto/send-notification.dto';
+import { UpdatePreferencesDto } from './dto/notification.dto';
 import { NotificationPreference } from './entities/notification-preference.entity';
 import { NotificationChannel } from './entities/notification.entity';
+import { NotificationStatus } from '../common/enums/notification-status.enum';
 
-interface UpdatePreferenceDto {
+interface ChannelPreferenceDto {
   type: string;
   channel: NotificationChannel;
   enabled: boolean;
 }
 
+@ApiTags('notification')
 @Controller('notification')
 export class NotificationController {
   constructor(private readonly notificationService: NotificationService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Send a notification' })
+  @ApiResponse({ status: 201, description: 'Notification sent' })
   send(@Body() dto: SendNotificationDto) {
     return this.notificationService.send(dto);
   }
 
   @Get('preferences/:userId')
+  @ApiOperation({ summary: 'Get per-channel notification preferences for a user' })
+  @ApiResponse({ status: 200, description: 'Notification preferences array' })
   getPreferences(@Param('userId') userId: string): Promise<NotificationPreference[]> {
     return this.notificationService.getPreferences(Number(userId));
   }
 
   @Patch('preferences/:userId')
+  @ApiOperation({ summary: 'Update per-channel notification preferences for a user' })
+  @ApiResponse({ status: 200, description: 'Updated preferences' })
   updatePreferences(
     @Param('userId') userId: string,
-    @Body() body: UpdatePreferenceDto[],
+    @Body() body: ChannelPreferenceDto[],
   ) {
     return this.notificationService.updatePreferences(Number(userId), body);
   }
 
+  @Get('settings/:userId')
+  @ApiOperation({ summary: 'Get high-level notification settings for a user (frequency, channels, type toggles)' })
+  @ApiResponse({ status: 200, description: 'User notification settings' })
+  getUserSettings(@Param('userId') userId: string) {
+    return this.notificationService.getUserNotificationPreferences(userId);
+  }
+
+  @Patch('settings/:userId')
+  @ApiOperation({ summary: 'Update high-level notification settings for a user' })
+  @ApiResponse({ status: 200, description: 'Updated notification settings' })
+  updateUserSettings(
+    @Param('userId') userId: string,
+    @Body(new ValidationPipe({ whitelist: true, transform: true }))
+    dto: UpdatePreferencesDto,
+  ) {
+    return this.notificationService.updateUserNotificationPreferences(userId, dto);
+  }
+
   @Get('unsubscribe')
+  @ApiOperation({ summary: 'Unsubscribe from notifications via token' })
+  @ApiQuery({ name: 'token', required: true, type: String })
+  @ApiResponse({ status: 200, description: 'Unsubscribed successfully' })
   unsubscribe(@Query('token') token: string) {
     return this.notificationService.unsubscribeByToken(token);
+  }
+
+  @Get(':userId')
+  @ApiOperation({ summary: 'Get notifications for a user' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'offset', required: false, type: Number })
+  @ApiQuery({ name: 'status', required: false, enum: NotificationStatus })
+  @ApiResponse({ status: 200, description: 'List of notifications' })
+  getNotifications(
+    @Param('userId') userId: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('status') status?: NotificationStatus,
+  ) {
+    return this.notificationService.getNotifications(Number(userId), {
+      limit: limit ? Number(limit) : undefined,
+      offset: offset ? Number(offset) : undefined,
+      status,
+    });
+  }
+
+  @Post(':notificationId/read')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mark a notification as read' })
+  @ApiBody({ schema: { properties: { userId: { type: 'number' } }, required: ['userId'] } })
+  @ApiResponse({ status: 200, description: 'Notification marked as read' })
+  markAsRead(
+    @Param('notificationId') notificationId: string,
+    @Body('userId') userId: number,
+  ) {
+    return this.notificationService.markAsRead(Number(notificationId), Number(userId));
   }
 }

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -6,6 +6,7 @@ import { Notification } from './entities/notification.entity';
 import { NotificationPreference } from './entities/notification-preference.entity';
 import { NotificationTemplate } from './entities/notification-template.entity';
 import { NotificationJob } from './entities/notification-job.entity';
+import { UserNotificationPreferences } from './entities/user-notification-preferences.entity';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { NotificationJob } from './entities/notification-job.entity';
       NotificationPreference,
       NotificationTemplate,
       NotificationJob,
+      UserNotificationPreferences,
     ]),
   ],
   controllers: [NotificationController],

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -22,6 +22,10 @@ import * as Handlebars from 'handlebars';
 import { SendNotificationDto } from './dto/send-notification.dto';
 import { NotificationStatus } from '../common/enums/notification-status.enum';
 import { AuditNotifierService } from 'src/audit-log/audit-notifier.service';
+import {
+  UserNotificationPreferences,
+  NotificationFrequency,
+} from './entities/user-notification-preferences.entity';
 
 interface DeliveryContext {
   [key: string]: unknown;
@@ -42,6 +46,8 @@ export class NotificationService {
     private readonly templateRepo: Repository<NotificationTemplate>,
     @InjectRepository(NotificationJob)
     private readonly jobRepo: Repository<NotificationJob>,
+    @InjectRepository(UserNotificationPreferences)
+    private readonly userPrefsRepo: Repository<UserNotificationPreferences>,
   ) {
     this.mailer = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
@@ -285,9 +291,66 @@ export class NotificationService {
     });
   }
 
-  private async deliverInApp(notification: Notification) {}
+  private async deliverInApp(notification: Notification): Promise<void> {
+    // In-app delivery: the notification record is already persisted in the DB
+    // with status=SENT. Clients poll GET /notification/:userId or receive real-time
+    // updates via WebSocket ('user.notification.received').
+    // No additional transport is required — the record IS the delivery.
+    this.logger.log(
+      `In-app notification delivered: id=${notification.id} userId=${notification.userId}`,
+    );
+  }
 
-  private async deliverPush(notification: Notification) {}
+  private async deliverPush(notification: Notification): Promise<void> {
+    // Push delivery via FCM. Requires PUSH_PROVIDER=fcm and FIREBASE_SERVER_KEY env vars.
+    // The device token must be passed in notification.metadata.deviceToken.
+    const deviceToken = notification.metadata?.deviceToken as string | undefined;
+    const provider = process.env.PUSH_PROVIDER ?? 'none';
+
+    if (!deviceToken) {
+      this.logger.warn(
+        `Push skipped — no deviceToken in metadata: notificationId=${notification.id}`,
+      );
+      return;
+    }
+
+    if (provider !== 'fcm') {
+      this.logger.warn(
+        `Push skipped — PUSH_PROVIDER="${provider}" not configured. Set PUSH_PROVIDER=fcm and FIREBASE_SERVER_KEY to enable.`,
+      );
+      return;
+    }
+
+    const firebaseKey = process.env.FIREBASE_SERVER_KEY;
+    if (!firebaseKey) {
+      throw new BadRequestException('FIREBASE_SERVER_KEY env variable is not set');
+    }
+
+    const { subject, body } = await this.resolveTemplate(notification);
+
+    const payload = {
+      to: deviceToken,
+      notification: { title: subject || notification.type, body },
+      data: { notificationId: String(notification.id), type: notification.type },
+    };
+
+    const response = await fetch('https://fcm.googleapis.com/fcm/send', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `key=${firebaseKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`FCM push failed: ${response.status} ${response.statusText}`);
+    }
+
+    this.logger.log(
+      `Push notification sent via FCM: id=${notification.id} userId=${notification.userId}`,
+    );
+  }
 
   async getPreferences(userId: number) {
     return this.preferenceRepo.find({ where: { userId } });
@@ -347,5 +410,98 @@ export class NotificationService {
   ) {
     const base = `${userId}:${type}:${channel}:${Date.now()}`;
     return Buffer.from(base).toString('base64url');
+  }
+
+  async sendAlert(dto: {
+    userId: number;
+    message: string;
+    subject?: string;
+    channels: NotificationChannel[];
+    type: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<Notification> {
+    return this.send(
+      {
+        userId: dto.userId,
+        type: dto.type,
+        message: dto.message,
+        subject: dto.subject,
+        channels: dto.channels,
+      },
+      dto.metadata ?? {},
+    );
+  }
+
+  async sendEvent(
+    userId: number,
+    eventType: string,
+    message: string,
+  ): Promise<Notification> {
+    return this.send({
+      userId,
+      type: eventType,
+      message,
+      channels: [NotificationChannel.InApp],
+    });
+  }
+
+  async getNotifications(
+    userId: number,
+    opts: { limit?: number; offset?: number; status?: NotificationStatus } = {},
+  ): Promise<Notification[]> {
+    const { limit = 20, offset = 0, status } = opts;
+    const where: Record<string, unknown> = { userId };
+    if (status) where.status = status;
+
+    return this.notificationRepo.find({
+      where: where as any,
+      order: { createdAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+  }
+
+  async markAsRead(notificationId: number, userId: number): Promise<Notification> {
+    const notification = await this.notificationRepo.findOne({
+      where: { id: notificationId, userId },
+    });
+    if (!notification) {
+      throw new NotFoundException('Notification not found');
+    }
+    notification.status = NotificationStatus.READ;
+    notification.readAt = new Date();
+    return this.notificationRepo.save(notification);
+  }
+
+  async getUserNotificationPreferences(userId: string): Promise<UserNotificationPreferences> {
+    let prefs = await this.userPrefsRepo.findOne({ where: { userId } });
+    if (!prefs) {
+      prefs = this.userPrefsRepo.create({
+        userId,
+        frequency: NotificationFrequency.INSTANT,
+        channels: [NotificationChannel.InApp, NotificationChannel.Email],
+        tradeNotifications: true,
+        balanceNotifications: true,
+        milestoneNotifications: true,
+      });
+      prefs = await this.userPrefsRepo.save(prefs);
+    }
+    return prefs;
+  }
+
+  async updateUserNotificationPreferences(
+    userId: string,
+    updates: Partial<Pick<
+      UserNotificationPreferences,
+      'frequency' | 'channels' | 'tradeNotifications' | 'balanceNotifications' | 'milestoneNotifications'
+    >>,
+  ): Promise<UserNotificationPreferences> {
+    let prefs = await this.userPrefsRepo.findOne({ where: { userId } });
+    if (!prefs) {
+      prefs = this.userPrefsRepo.create({ userId, ...updates });
+    } else {
+      Object.assign(prefs, updates);
+    }
+    return this.userPrefsRepo.save(prefs);
   }
 }

--- a/src/queue/queue.constants.ts
+++ b/src/queue/queue.constants.ts
@@ -4,4 +4,5 @@ export enum QueueName {
   REPORTS = 'reports',
   CLEANUP = 'cleanup',
   SWAPS = 'swaps',
+  ALERTS = 'alerts',
 }


### PR DESCRIPTION
## Summary

This PR implements a full **Customizable Notification & Alert System** allowing users to configure real-time alerts for trading events and receive notifications across email, SMS, in-app, and push channels.

---

## Changes

### New: Alert System (`src/alerts/`)

- **`AlertRule` entity** — user-defined alert rules with three types:
  - `PRICE` — fires when an asset's price crosses a threshold (`GT`, `LT`, `GTE`, `LTE`)
  - `VOLUME` — fires when 24h volume crosses a threshold
  - `PORTFOLIO_CHANGE` — fires when portfolio value changes by a percentage or absolute amount
- **`AlertTriggeredEvent` entity** — immutable audit log of every alert firing (value at trigger, notification ID, channel used)
- **`AlertEvaluationService`** — event-driven engine:
  - Listens to `market.data.updated` for PRICE/VOLUME alerts
  - Listens to `user.portfolio.updated` for PORTFOLIO_CHANGE alerts
  - Enforces per-alert cooldown windows to prevent notification spam
  - Stores a `referenceValue` baseline for portfolio change calculations
- **`AlertProcessor`** — Bull queue processor (`concurrency: 5`) that re-verifies alert status before firing, delivers via `NotificationService`, and records each trigger
- **`AlertController`** — 8 REST endpoints:

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/alerts/:userId` | Create alert |
| `GET` | `/alerts/:userId` | List alerts |
| `GET` | `/alerts/:userId/:alertId` | Get alert |
| `PATCH` | `/alerts/:userId/:alertId` | Update alert |
| `DELETE` | `/alerts/:userId/:alertId` | Delete alert |
| `POST` | `/alerts/:userId/:alertId/pause` | Pause alert |
| `POST` | `/alerts/:userId/:alertId/resume` | Resume alert |
| `GET` | `/alerts/:userId/:alertId/history` | Trigger history |

---

### Enhanced: Notification System (`src/notification/`)

- **`NotificationService`** — 4 new methods:
  - `sendAlert()` — dedicated entry point for alert-triggered notifications
  - `sendEvent()` — fixes a latent bug where `TradingService` called this method but it didn't exist
  - `getNotifications()` — paginated notification list with status filter
  - `markAsRead()` — marks a notification as read with timestamp
  - `getUserNotificationPreferences()` — upsert-based retrieval of high-level user settings
  - `updateUserNotificationPreferences()` — update frequency, channels, and notification type toggles

- **`NotificationController`** — 4 new endpoints:

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/notification/:userId` | List notifications (paginated, filterable by status) |
| `POST` | `/notification/:notificationId/read` | Mark notification as read |
| `GET` | `/notification/settings/:userId` | Get high-level notification settings |
| `PATCH` | `/notification/settings/:userId` | Update frequency, channels, type toggles |

- **`deliverInApp()`** — implemented: the persisted notification record IS the delivery; logged for observability
- **`deliverPush()`** — implemented via Firebase Cloud Messaging (FCM); gracefully degrades if `PUSH_PROVIDER` / `FIREBASE_SERVER_KEY` env vars are not configured

- **`UserNotificationPreferences` entity** — registered in `NotificationModule` and wired end-to-end (was previously defined but unused)
- **Enum conflict fixed** — `user-notification-preferences.entity.ts` was defining its own `NotificationChannel` enum with incompatible values (`'in-app'`, `'email'`); now imports the canonical enum (`'IN_APP'`, `'EMAIL'`) from `notification.entity.ts`
- **`notification.dto.ts`** — `UpdatePreferencesDto` import updated to use canonical enum sources

---

### Infrastructure

- **`QueueName.ALERTS`** added to `src/queue/queue.constants.ts`
- **`MarketDataService`** now injects `EventEmitter2` and emits `market.data.updated` after each validated price update — this event was listened to by `WebSocketEvents` but was never actually emitted, meaning the entire real-time market data pipeline to WebSocket clients was broken
- **`AlertModule`** registered in `AppModule`

---

### Documentation

- **`docs/NOTIFICATION_ALERT_SYSTEM.md`** — comprehensive configuration guide covering:
  - All required environment variables (SMTP, Twilio, FCM)
  - Alert API with full request/response examples
  - Notification preferences API
  - Per-channel delivery details and requirements
  - Template system usage
  - Reliability mechanisms (retry, cooldown, daily limits)

---

## Acceptance Criteria

- [x] Users can set custom alerts (price, volume, portfolio change)
- [x] Notifications delivered reliably (Bull queue, exponential backoff, 5 retry attempts)
- [x] Email delivery — nodemailer (SMTP)
- [x] SMS delivery — Twilio
- [x] In-app delivery — database-persisted, polled via API
- [x] Push delivery — Firebase Cloud Messaging (FCM)
- [x] Notification preferences per user (per-channel granular + high-level settings)
- [x] Alert triggers for price, volume, and portfolio changes
- [x] Integrated with existing notification service
- [x] Notification configuration documented

---

Closes #165
