### PR TITLE
feat(waitlist): Add comprehensive analytics and metrics

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,8 @@ import { TutorialModule } from './tutorial/tutorial.module';
 import { GqlAppModule } from './graphql/graphql.module';
 import { AuditLogModule } from './audit-log/audit-log.module';
 import { AlertModule } from './alerts/alert.module';
+import { WaitlistModule } from './waitlist/waitlist.module';
+import { WaitlistAnalyticsModule } from './waitlist-analytics/waitlist-analytics.module';
 
 @Module({
   imports: [
@@ -47,6 +49,8 @@ import { AlertModule } from './alerts/alert.module';
     ExportModule,
     AuditLogModule,
     AlertModule,
+    WaitlistModule,
+    WaitlistAnalyticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -1,12 +1,3 @@
-  readonly botTradesTotal = new Counter({
-    name: 'bot_trades_total',
-    help: 'Total number of trades executed by bots',
-    labelNames: ['botId', 'asset', 'type'],
-    registers: [this.registry],
-  });
-  recordBotTrade(botId: number, asset: string, type: string): void {
-    this.botTradesTotal.labels(botId.toString(), asset, type).inc();
-  }
 import { Injectable } from '@nestjs/common';
 import {
   Counter,
@@ -20,6 +11,7 @@ import {
 export class MetricsService {
   private readonly registry = new Registry();
 
+  // HTTP Metrics
   readonly httpRequestsTotal = new Counter({
     name: 'http_requests_total',
     help: 'Total number of HTTP requests',
@@ -35,6 +27,7 @@ export class MetricsService {
     buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
   });
 
+  // Database Metrics
   readonly dbQueryTotal = new Counter({
     name: 'db_query_total',
     help: 'Total number of database queries',
@@ -57,6 +50,7 @@ export class MetricsService {
     buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
   });
 
+  // Cache Metrics
   readonly cacheRequestsTotal = new Counter({
     name: 'cache_requests_total',
     help: 'Total number of cache requests',
@@ -67,6 +61,51 @@ export class MetricsService {
   readonly cacheHitRatio = new Gauge({
     name: 'cache_hit_ratio',
     help: 'Cache hit ratio (hits / (hits + misses))',
+    registers: [this.registry],
+  });
+
+  // Waitlist & Referral Metrics
+  readonly waitlistSignupsTotal = new Gauge({
+    name: 'waitlist_signups_total',
+    help: 'Total number of waitlist signups',
+    registers: [this.registry],
+  });
+
+  readonly waitlistVerifiedUsers = new Gauge({
+    name: 'waitlist_verified_users',
+    help: 'Total number of verified waitlist users',
+    registers: [this.registry],
+  });
+
+  readonly waitlistPendingUsers = new Gauge({
+    name: 'waitlist_pending_users',
+    help: 'Total number of pending waitlist users',
+    registers: [this.registry],
+  });
+
+  readonly referralConversionsTotal = new Gauge({
+    name: 'referral_conversions_total',
+    help: 'Total number of successful referral conversions',
+    registers: [this.registry],
+  });
+
+  readonly referralConversionRate = new Gauge({
+    name: 'referral_conversion_rate',
+    help: 'Referral conversion rate as percentage',
+    registers: [this.registry],
+  });
+
+  readonly waitlistVerificationRate = new Gauge({
+    name: 'waitlist_verification_rate',
+    help: 'Waitlist verification rate as percentage',
+    registers: [this.registry],
+  });
+
+  // Bot Trading Metrics
+  readonly botTradesTotal = new Counter({
+    name: 'bot_trades_total',
+    help: 'Total number of trades executed by bots',
+    labelNames: ['botId', 'asset', 'type'],
     registers: [this.registry],
   });
 
@@ -85,11 +124,13 @@ export class MetricsService {
     return this.registry.metrics();
   }
 
+  // HTTP Recording Methods
   recordHttpRequest(method: string, route: string, status: number, durationSeconds: number): void {
     this.httpRequestsTotal.labels(method, route, status.toString()).inc();
     this.httpRequestDurationSeconds.labels(method, route, status.toString()).observe(durationSeconds);
   }
 
+  // Database Recording Methods
   recordDbQuery(operation: string, success: boolean): void {
     this.dbQueryTotal.labels(operation, success ? 'true' : 'false').inc();
   }
@@ -99,6 +140,7 @@ export class MetricsService {
     this.dbQueryDurationSeconds.labels(operation).observe(durationMs / 1000);
   }
 
+  // Cache Recording Methods
   recordCacheHit(): void {
     this.cacheHits += 1;
     this.cacheRequestsTotal.labels('hit').inc();
@@ -123,5 +165,27 @@ export class MetricsService {
     const total = this.cacheHits + this.cacheMisses;
     const ratio = total > 0 ? this.cacheHits / total : 0;
     this.cacheHitRatio.set(ratio);
+  }
+
+  // Waitlist Metrics Methods
+  setWaitlistMetrics(stats: {
+    totalSignups: number;
+    verifiedUsers: number;
+    pendingUsers: number;
+    referralConversions: number;
+    referralConversionRate: number;
+    verificationRate: number;
+  }): void {
+    this.waitlistSignupsTotal.set(stats.totalSignups);
+    this.waitlistVerifiedUsers.set(stats.verifiedUsers);
+    this.waitlistPendingUsers.set(stats.pendingUsers);
+    this.referralConversionsTotal.set(stats.referralConversions);
+    this.referralConversionRate.set(stats.referralConversionRate);
+    this.waitlistVerificationRate.set(stats.verificationRate);
+  }
+
+  // Bot Trading Recording Methods
+  recordBotTrade(botId: number, asset: string, type: string): void {
+    this.botTradesTotal.labels(botId.toString(), asset, type).inc();
   }
 }

--- a/src/waitlist-analytics/dto/waitlist-stats.dto.ts
+++ b/src/waitlist-analytics/dto/waitlist-stats.dto.ts
@@ -1,0 +1,78 @@
+export class WaitlistStatsDto {
+  /** Total number of waitlist signups */
+  totalSignups: number;
+  
+  /** Number of verified users */
+  verifiedUsers: number;
+  
+  /** Number of pending users */
+  pendingUsers: number;
+  
+  /** Number of invited users */
+  invitedUsers: number;
+  
+  /** Total referral conversions (verified users who were referred) */
+  referralConversions: number;
+  
+  /** Referral conversion rate (conversions / total signups) */
+  referralConversionRate: number;
+  
+  /** Verification rate (verified / total signups) */
+  verificationRate: number;
+  
+  /** Top referrers with their stats */
+  topReferrers: ReferrerStatsDto[];
+  
+  /** Daily signup trends */
+  dailyTrends: DailyTrendDto[];
+  
+  /** Timestamp of stats generation */
+  generatedAt: Date;
+}
+
+export class ReferrerStatsDto {
+  /** Referrer's referral code */
+  referralCode: string;
+  
+  /** Number of successful referrals */
+  referralCount: number;
+  
+  /** Number of verified referrals */
+  verifiedReferrals: number;
+}
+
+export class DailyTrendDto {
+  /** Date in YYYY-MM-DD format */
+  date: string;
+  
+  /** Number of signups on this date */
+  signups: number;
+  
+  /** Number of verifications on this date */
+  verifications: number;
+  
+  /** Number of referral conversions on this date */
+  conversions: number;
+}
+
+export class WaitlistMetricsDto {
+  /** Prometheus-compatible metric name */
+  name: string;
+  
+  /** Metric help text */
+  help: string;
+  
+  /** Metric type (gauge, counter) */
+  type: string;
+  
+  /** Current value */
+  value: number;
+  
+  /** Labels attached to the metric */
+  labels: Record<string, string>;
+}
+
+export class DateRangeDto {
+  startDate: Date;
+  endDate: Date;
+}

--- a/src/waitlist-analytics/index.ts
+++ b/src/waitlist-analytics/index.ts
@@ -1,0 +1,4 @@
+export * from './waitlist-analytics.module';
+export * from './waitlist-analytics.service';
+export * from './waitlist-analytics.controller';
+export * from './dto/waitlist-stats.dto';

--- a/src/waitlist-analytics/waitlist-analytics.controller.ts
+++ b/src/waitlist-analytics/waitlist-analytics.controller.ts
@@ -1,0 +1,105 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  HttpStatus,
+  HttpCode,
+} from '@nestjs/common';
+import { WaitlistAnalyticsService } from './waitlist-analytics.service';
+import { WaitlistStatsDto } from './dto/waitlist-stats.dto';
+
+@Controller('admin/waitlist')
+export class WaitlistAnalyticsController {
+  constructor(
+    private readonly analyticsService: WaitlistAnalyticsService,
+  ) {}
+
+  /**
+   * Get comprehensive waitlist statistics
+   * GET /api/admin/waitlist/stats
+   * 
+   * Query params:
+   * - days: number of days for daily trends (default: 30)
+   */
+  @Get('stats')
+  @HttpCode(HttpStatus.OK)
+  async getStats(
+    @Query('days') days?: number,
+  ): Promise<WaitlistStatsDto> {
+    return this.analyticsService.getStats(days);
+  }
+
+  /**
+   * Get summary stats for dashboard
+   * GET /api/admin/waitlist/stats/summary
+   */
+  @Get('stats/summary')
+  @HttpCode(HttpStatus.OK)
+  async getSummaryStats(): Promise<{
+    totalSignups: number;
+    verifiedUsers: number;
+    verificationRate: number;
+    topReferrer: any;
+    todaySignups: number;
+    todayVerifications: number;
+  }> {
+    return this.analyticsService.getSummaryStats();
+  }
+
+  /**
+   * Get top referrers
+   * GET /api/admin/waitlist/referrers
+   * 
+   * Query params:
+   * - limit: number of referrers to return (default: 10)
+   */
+  @Get('referrers')
+  @HttpCode(HttpStatus.OK)
+  async getTopReferrers(
+    @Query('limit') limit?: number,
+  ): Promise<{ referrers: any[] }> {
+    const referrers = await this.analyticsService.getTopReferrers(limit || 10);
+    return { referrers };
+  }
+
+  /**
+   * Get daily trends
+   * GET /api/admin/waitlist/trends
+   * 
+   * Query params:
+   * - days: number of days to include (default: 30)
+   */
+  @Get('trends')
+  @HttpCode(HttpStatus.OK)
+  async getDailyTrends(
+    @Query('days') days?: number,
+  ): Promise<{ trends: any[] }> {
+    const trends = await this.analyticsService.getDailyTrends(days || 30);
+    return { trends };
+  }
+
+  /**
+   * Get stats for a specific date range
+   * GET /api/admin/waitlist/stats/range
+   * 
+   * Query params:
+   * - startDate: ISO date string
+   * - endDate: ISO date string
+   */
+  @Get('stats/range')
+  @HttpCode(HttpStatus.OK)
+  async getStatsForDateRange(
+    @Query('startDate') startDate: string,
+    @Query('endDate') endDate: string,
+  ): Promise<Partial<WaitlistStatsDto>> {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      throw new Error('Invalid date format. Use ISO date string.');
+    }
+    
+    return this.analyticsService.getStatsForDateRange(start, end);
+  }
+}

--- a/src/waitlist-analytics/waitlist-analytics.module.ts
+++ b/src/waitlist-analytics/waitlist-analytics.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WaitlistAnalyticsController } from './waitlist-analytics.controller';
+import { WaitlistAnalyticsService } from './waitlist-analytics.service';
+import { WaitlistUser } from '../waitlist/entities/waitlist-user.entity';
+import { MetricsModule } from '../metrics/metrics.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([WaitlistUser]),
+    MetricsModule,
+  ],
+  controllers: [WaitlistAnalyticsController],
+  providers: [WaitlistAnalyticsService],
+  exports: [WaitlistAnalyticsService],
+})
+export class WaitlistAnalyticsModule {}

--- a/src/waitlist-analytics/waitlist-analytics.service.spec.ts
+++ b/src/waitlist-analytics/waitlist-analytics.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WaitlistAnalyticsService } from './waitlist-analytics.service';
+import { WaitlistUser, WaitlistStatus } from '../waitlist/entities/waitlist-user.entity';
+import { MetricsService } from '../../metrics/metrics.service';
+
+describe('WaitlistAnalyticsService', () => {
+  let service: WaitlistAnalyticsService;
+  let mockRepo: jest.Mocked<Repository<WaitlistUser>>;
+  let mockMetricsService: jest.Mocked<MetricsService>;
+
+  const mockWaitlistUser = {
+    id: 'test-id',
+    email: 'test@example.com',
+    name: 'Test User',
+    status: WaitlistStatus.VERIFIED,
+    referralCode: 'TEST1234',
+    referredBy: null,
+    createdAt: new Date(),
+    verifiedAt: new Date(),
+  } as WaitlistUser;
+
+  beforeEach(async () => {
+    mockRepo = {
+      count: jest.fn(),
+      createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
+    } as any;
+
+    mockMetricsService = {
+      setWaitlistMetrics: jest.fn(),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WaitlistAnalyticsService,
+        {
+          provide: getRepositoryToken(WaitlistUser),
+          useValue: mockRepo,
+        },
+        {
+          provide: MetricsService,
+          useValue: mockMetricsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WaitlistAnalyticsService>(WaitlistAnalyticsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getStats', () => {
+    it('should return comprehensive statistics', async () => {
+      mockRepo.count
+        .mockResolvedValueOnce(100) // totalSignups
+        .mockResolvedValueOnce(60) // verifiedUsers
+        .mockResolvedValueOnce(30) // pendingUsers
+        .mockResolvedValueOnce(10) // invitedUsers
+        .mockResolvedValueOnce(25); // referralConversions
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockRepo.createQueryBuilder
+        .mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getStats(30);
+
+      expect(result.totalSignups).toBe(100);
+      expect(result.verifiedUsers).toBe(60);
+      expect(result.pendingUsers).toBe(30);
+      expect(result.invitedUsers).toBe(10);
+      expect(result.referralConversions).toBe(25);
+      expect(result.verificationRate).toBe(60);
+      expect(result.referralConversionRate).toBe(25);
+      expect(result.topReferrers).toEqual([]);
+      expect(result.dailyTrends).toBeDefined();
+      expect(mockMetricsService.setWaitlistMetrics).toHaveBeenCalled();
+    });
+  });
+
+  describe('getTopReferrers', () => {
+    it('should return top referrers sorted by referral count', async () => {
+      const mockReferrers = [
+        { referralCode: 'ABC12345', referralCount: '10', verifiedReferrals: '8' },
+        { referralCode: 'DEF67890', referralCount: '5', verifiedReferrals: '3' },
+      ];
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(mockReferrers),
+      };
+
+      mockRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getTopReferrers(10);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].referralCode).toBe('ABC12345');
+      expect(result[0].referralCount).toBe(10);
+      expect(result[0].verifiedReferrals).toBe(8);
+    });
+  });
+
+  describe('getDailyTrends', () => {
+    it('should return daily trends for specified days', async () => {
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getDailyTrends(7);
+
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+    });
+  });
+
+  describe('getSummaryStats', () => {
+    it('should return summary stats including today stats', async () => {
+      mockRepo.count
+        .mockResolvedValueOnce(100) // totalSignups
+        .mockResolvedValueOnce(60) // verifiedUsers
+        .mockResolvedValueOnce(30) // pendingUsers
+        .mockResolvedValueOnce(25) // referralConversions
+        .mockResolvedValueOnce(5) // todaySignups
+        .mockResolvedValueOnce(3); // todayVerifications
+
+      const mockQueryBuilder = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+
+      mockRepo.createQueryBuilder.mockReturnValue(mockQueryBuilder as any);
+
+      const result = await service.getSummaryStats();
+
+      expect(result.totalSignups).toBe(100);
+      expect(result.verifiedUsers).toBe(60);
+      expect(result.verificationRate).toBe(60);
+    });
+  });
+});

--- a/src/waitlist-analytics/waitlist-analytics.service.ts
+++ b/src/waitlist-analytics/waitlist-analytics.service.ts
@@ -1,0 +1,321 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { WaitlistUser, WaitlistStatus } from '../waitlist/entities/waitlist-user.entity';
+import { MetricsService } from '../../metrics/metrics.service';
+import {
+  WaitlistStatsDto,
+  ReferrerStatsDto,
+  DailyTrendDto,
+} from './dto/waitlist-stats.dto';
+
+@Injectable()
+export class WaitlistAnalyticsService {
+  private readonly logger = new Logger(WaitlistAnalyticsService.name);
+
+  constructor(
+    @InjectRepository(WaitlistUser)
+    private readonly waitlistRepo: Repository<WaitlistUser>,
+    private readonly metricsService: MetricsService,
+  ) {}
+
+  /**
+   * Get comprehensive waitlist statistics
+   */
+  async getStats(days?: number): Promise<WaitlistStatsDto> {
+    this.logger.log('Generating waitlist statistics');
+
+    // Get basic counts
+    const [
+      totalSignups,
+      verifiedUsers,
+      pendingUsers,
+      invitedUsers,
+      referralConversions,
+    ] = await Promise.all([
+      this.getTotalSignups(),
+      this.getVerifiedUsers(),
+      this.getUsersByStatus(WaitlistStatus.PENDING),
+      this.getUsersByStatus(WaitlistStatus.INVITED),
+      this.getReferralConversions(),
+    ]);
+
+    // Calculate rates
+    const verificationRate = totalSignups > 0 
+      ? Number((verifiedUsers / totalSignups * 100).toFixed(2))
+      : 0;
+    
+    const referralConversionRate = totalSignups > 0
+      ? Number((referralConversions / totalSignups * 100).toFixed(2))
+      : 0;
+
+    // Get top referrers and daily trends in parallel
+    const [topReferrers, dailyTrends] = await Promise.all([
+      this.getTopReferrers(10),
+      this.getDailyTrends(days || 30),
+    ]);
+
+    // Update Prometheus metrics
+    this.updatePrometheusMetrics({
+      totalSignups,
+      verifiedUsers,
+      pendingUsers,
+      referralConversions,
+    });
+
+    return {
+      totalSignups,
+      verifiedUsers,
+      pendingUsers,
+      invitedUsers,
+      referralConversions,
+      referralConversionRate,
+      verificationRate,
+      topReferrers,
+      dailyTrends,
+      generatedAt: new Date(),
+    };
+  }
+
+  /**
+   * Get total number of signups
+   */
+  private async getTotalSignups(): Promise<number> {
+    return this.waitlistRepo.count();
+  }
+
+  /**
+   * Get number of verified users
+   */
+  private async getVerifiedUsers(): Promise<number> {
+    return this.waitlistRepo.count({
+      where: { status: WaitlistStatus.VERIFIED },
+    });
+  }
+
+  /**
+   * Get users count by status
+   */
+  private async getUsersByStatus(status: WaitlistStatus): Promise<number> {
+    return this.waitlistRepo.count({
+      where: { status },
+    });
+  }
+
+  /**
+   * Get number of referral conversions (verified users who were referred)
+   */
+  private async getReferralConversions(): Promise<number> {
+    return this.waitlistRepo.count({
+      where: {
+        status: WaitlistStatus.VERIFIED,
+        referredBy: Not(null),
+      } as any,
+    });
+  }
+
+  /**
+   * Get top referrers with their stats
+   */
+  async getTopReferrers(limit: number = 10): Promise<ReferrerStatsDto[]> {
+    // Query to get referral counts grouped by referrer
+    const referrers = await this.waitlistRepo
+      .createQueryBuilder('referrer')
+      .select('referrer.referralCode', 'referralCode')
+      .addSelect('COUNT(referred.id)', 'referralCount')
+      .addSelect(
+        'SUM(CASE WHEN referred.status = :verified THEN 1 ELSE 0 END)',
+        'verifiedReferrals'
+      )
+      .innerJoin(
+        WaitlistUser,
+        'referred',
+        'referred.referredBy = referrer.referralCode'
+      )
+      .where('referrer.referralCode IS NOT NULL')
+      .setParameter('verified', WaitlistStatus.VERIFIED)
+      .groupBy('referrer.referralCode')
+      .orderBy('referralCount', 'DESC')
+      .limit(limit)
+      .getRawMany();
+
+    return referrers.map(r => ({
+      referralCode: r.referralCode,
+      referralCount: parseInt(r.referralCount, 10),
+      verifiedReferrals: parseInt(r.verifiedReferrals, 10),
+    }));
+  }
+
+  /**
+   * Get daily trends for the specified number of days
+   */
+  async getDailyTrends(days: number = 30): Promise<DailyTrendDto[]> {
+    const endDate = new Date();
+    endDate.setHours(23, 59, 59, 999);
+    
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days + 1);
+    startDate.setHours(0, 0, 0, 0);
+
+    // Get daily signups
+    const dailySignups = await this.waitlistRepo
+      .createQueryBuilder('user')
+      .select("DATE(user.createdAt)", 'date')
+      .addSelect('COUNT(*)', 'signups')
+      .where('user.createdAt BETWEEN :startDate AND :endDate', { startDate, endDate })
+      .groupBy("DATE(user.createdAt)")
+      .orderBy('date', 'ASC')
+      .getRawMany();
+
+    // Get daily verifications
+    const dailyVerifications = await this.waitlistRepo
+      .createQueryBuilder('user')
+      .select("DATE(user.verifiedAt)", 'date')
+      .addSelect('COUNT(*)', 'verifications')
+      .where('user.verifiedAt BETWEEN :startDate AND :endDate', { startDate, endDate })
+      .andWhere('user.status = :verified', { verified: WaitlistStatus.VERIFIED })
+      .groupBy("DATE(user.verifiedAt)")
+      .getRawMany();
+
+    // Get daily conversions
+    const dailyConversions = await this.waitlistRepo
+      .createQueryBuilder('user')
+      .select("DATE(user.verifiedAt)", 'date')
+      .addSelect('COUNT(*)', 'conversions')
+      .where('user.verifiedAt BETWEEN :startDate AND :endDate', { startDate, endDate })
+      .andWhere('user.referredBy IS NOT NULL')
+      .andWhere('user.status = :verified', { verified: WaitlistStatus.VERIFIED })
+      .groupBy("DATE(user.verifiedAt)")
+      .getRawMany();
+
+    // Merge data into daily trends
+    const trendsMap = new Map<string, DailyTrendDto>();
+
+    // Initialize all dates with zeros
+    for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+      const dateStr = d.toISOString().split('T')[0];
+      trendsMap.set(dateStr, {
+        date: dateStr,
+        signups: 0,
+        verifications: 0,
+        conversions: 0,
+      });
+    }
+
+    // Fill in signups
+    dailySignups.forEach(s => {
+      const trend = trendsMap.get(s.date);
+      if (trend) trend.signups = parseInt(s.signups, 10);
+    });
+
+    // Fill in verifications
+    dailyVerifications.forEach(v => {
+      const trend = trendsMap.get(v.date);
+      if (trend) trend.verifications = parseInt(v.verifications, 10);
+    });
+
+    // Fill in conversions
+    dailyConversions.forEach(c => {
+      const trend = trendsMap.get(c.date);
+      if (trend) trend.conversions = parseInt(c.conversions, 10);
+    });
+
+    return Array.from(trendsMap.values());
+  }
+
+  /**
+   * Get stats for a specific date range
+   */
+  async getStatsForDateRange(startDate: Date, endDate: Date): Promise<Partial<WaitlistStatsDto>> {
+    const [signups, verifications, conversions] = await Promise.all([
+      this.waitlistRepo.count({
+        where: { createdAt: Between(startDate, endDate) },
+      }),
+      this.waitlistRepo.count({
+        where: {
+          verifiedAt: Between(startDate, endDate),
+          status: WaitlistStatus.VERIFIED,
+        },
+      }),
+      this.waitlistRepo.count({
+        where: {
+          verifiedAt: Between(startDate, endDate),
+          status: WaitlistStatus.VERIFIED,
+          referredBy: Not(null),
+        } as any,
+      }),
+    ]);
+
+    return {
+      totalSignups: signups,
+      verifiedUsers: verifications,
+      referralConversions: conversions,
+      generatedAt: new Date(),
+    };
+  }
+
+  /**
+   * Update Prometheus metrics
+   */
+  private updatePrometheusMetrics(stats: {
+    totalSignups: number;
+    verifiedUsers: number;
+    pendingUsers: number;
+    referralConversions: number;
+  }): void {
+    try {
+      const verificationRate = stats.totalSignups > 0 
+        ? Number((stats.verifiedUsers / stats.totalSignups * 100).toFixed(2))
+        : 0;
+      
+      const referralConversionRate = stats.totalSignups > 0
+        ? Number((stats.referralConversions / stats.totalSignups * 100).toFixed(2))
+        : 0;
+
+      this.metricsService.setWaitlistMetrics({
+        ...stats,
+        referralConversionRate,
+        verificationRate,
+      });
+      
+      this.logger.debug('Updated Prometheus metrics', stats);
+    } catch (error) {
+      this.logger.error('Failed to update Prometheus metrics', error);
+    }
+  }
+
+  /**
+   * Get summary stats for admin dashboard
+   */
+  async getSummaryStats(): Promise<{
+    totalSignups: number;
+    verifiedUsers: number;
+    verificationRate: number;
+    topReferrer: ReferrerStatsDto | null;
+    todaySignups: number;
+    todayVerifications: number;
+  }> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+
+    const [stats, topReferrers, todayStats] = await Promise.all([
+      this.getStats(0),
+      this.getTopReferrers(1),
+      this.getStatsForDateRange(today, tomorrow),
+    ]);
+
+    return {
+      totalSignups: stats.totalSignups,
+      verifiedUsers: stats.verifiedUsers,
+      verificationRate: stats.verificationRate,
+      topReferrer: topReferrers[0] || null,
+      todaySignups: todayStats.totalSignups || 0,
+      todayVerifications: todayStats.verifiedUsers || 0,
+    };
+  }
+}
+
+// Import Not for TypeORM
+import { Not } from 'typeorm';


### PR DESCRIPTION
## Summary

Implements **Issue #203** - Analytics + Metrics

### Features

- **Comprehensive waitlist statistics**: signups, verifications, pending users, invited users
- **Top referrers ranking**: with referral counts and verified referral counts
- **Daily trends**: signup/verification/conversion tracking over time
- **Prometheus integration**: gauge metrics for monitoring dashboards
- **Admin API endpoints**: RESTful access to all statistics

### New Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/admin/waitlist/stats` | Full statistics with optional days parameter |
| `GET /api/admin/waitlist/stats/summary` | Dashboard summary (today stats, top referrer) |
| `GET /api/admin/waitlist/referrers` | Top referrers with limit parameter |
| `GET /api/admin/waitlist/trends` | Daily trends for charting |
| `GET /api/admin/waitlist/stats/range` | Custom date range statistics |

### Prometheus Metrics

| Metric | Type | Description |
|--------|------|-------------|
| `waitlist_signups_total` | Gauge | Total waitlist signups |
| `waitlist_verified_users` | Gauge | Verified users count |
| `waitlist_pending_users` | Gauge | Pending users count |
| `referral_conversions_total` | Gauge | Referral conversions |
| `referral_conversion_rate` | Gauge | Conversion rate % |
| `waitlist_verification_rate` | Gauge | Verification rate % |

### Files Added

```
src/waitlist-analytics/
├── dto/
│   └── waitlist-stats.dto.ts      # DTOs for stats responses
├── waitlist-analytics.module.ts   # Module definition
├── waitlist-analytics.service.ts  # Business logic
├── waitlist-analytics.controller.ts # API endpoints
├── waitlist-analytics.service.spec.ts # Unit tests
└── index.ts                       # Exports
```

### Testing

- Unit tests included for `WaitlistAnalyticsService`
- Tests cover: stats calculation, top referrers, daily trends, summary stats

### Bounty

This PR addresses bounty issue #203.