### PR TITLE
feat(exchange-rate): Add exchange rate service with caching

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { TutorialModule } from './tutorial/tutorial.module';
 import { GqlAppModule } from './graphql/graphql.module';
 import { AuditLogModule } from './audit-log/audit-log.module';
 import { AlertModule } from './alerts/alert.module';
+import { ExchangeRateModule } from './exchange-rate/exchange-rate.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { AlertModule } from './alerts/alert.module';
     ExportModule,
     AuditLogModule,
     AlertModule,
+    ExchangeRateModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/exchange-rate/dto/exchange-rate.dto.ts
+++ b/src/exchange-rate/dto/exchange-rate.dto.ts
@@ -1,0 +1,30 @@
+export class ExchangeRateResponseDto {
+  /** Base currency (USD) */
+  base: string;
+  
+  /** Exchange rates for different currencies */
+  rates: Record<string, number>;
+  
+  /** Timestamp of the last update */
+  lastUpdated: Date;
+  
+  /** Source of the exchange rate data */
+  source: string;
+}
+
+export class ExchangeRateErrorDto {
+  /** Error message */
+  error: string;
+  
+  /** Whether fallback data is being used */
+  isFallback: boolean;
+  
+  /** Timestamp of the last successful update */
+  lastSuccessfulUpdate?: Date;
+}
+
+export class CachedExchangeRate {
+  rates: Record<string, number>;
+  lastUpdated: Date;
+  source: string;
+}

--- a/src/exchange-rate/exchange-rate.controller.ts
+++ b/src/exchange-rate/exchange-rate.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Get,
+  Query,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { ExchangeRateService } from './exchange-rate.service';
+import { ExchangeRateResponseDto } from './dto/exchange-rate.dto';
+
+@Controller('exchange-rate')
+export class ExchangeRateController {
+  private readonly logger = new Logger(ExchangeRateController.name);
+
+  constructor(private readonly exchangeRateService: ExchangeRateService) {}
+
+  /**
+   * Get current USD exchange rates
+   * GET /api/exchange-rate
+   * 
+   * Returns all available exchange rates for USD base currency
+   */
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getRates(): Promise<ExchangeRateResponseDto> {
+    return this.exchangeRateService.getRates();
+  }
+
+  /**
+   * Get specific currency rate
+   * GET /api/exchange-rate/:currency
+   * 
+   * Query params:
+   * - currency: Currency code (e.g., EUR, GBP, JPY)
+   */
+  @Get('rate')
+  @HttpCode(HttpStatus.OK)
+  async getRate(
+    @Query('currency') currency: string,
+  ): Promise<{ currency: string; rate: number | null; base: string }> {
+    if (!currency) {
+      return { currency: '', rate: null, base: 'USD' };
+    }
+    
+    const rate = await this.exchangeRateService.getRate(currency);
+    return { currency: currency.toUpperCase(), rate, base: 'USD' };
+  }
+
+  /**
+   * Force refresh exchange rates
+   * GET /api/exchange-rate/refresh
+   * 
+   * Forces a cache clear and fetches fresh rates
+   */
+  @Get('refresh')
+  @HttpCode(HttpStatus.OK)
+  async refresh(): Promise<ExchangeRateResponseDto> {
+    this.logger.log('Exchange rate refresh requested');
+    return this.exchangeRateService.refresh();
+  }
+
+  /**
+   * Get service health status
+   * GET /api/exchange-rate/health
+   */
+  @Get('health')
+  @HttpCode(HttpStatus.OK)
+  async getHealth(): Promise<{
+    status: 'healthy' | 'degraded' | 'unhealthy';
+    lastUpdate: Date | null;
+    lastError: string | null;
+    source: string;
+  }> {
+    return this.exchangeRateService.getHealth();
+  }
+}

--- a/src/exchange-rate/exchange-rate.module.ts
+++ b/src/exchange-rate/exchange-rate.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ExchangeRateController } from './exchange-rate.controller';
+import { ExchangeRateService } from './exchange-rate.service';
+import { CustomCacheModule } from '../common/cache/cache.module';
+
+@Module({
+  imports: [
+    ConfigModule,
+    CustomCacheModule,
+  ],
+  controllers: [ExchangeRateController],
+  providers: [ExchangeRateService],
+  exports: [ExchangeRateService],
+})
+export class ExchangeRateModule {}

--- a/src/exchange-rate/exchange-rate.service.spec.ts
+++ b/src/exchange-rate/exchange-rate.service.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ExchangeRateService } from './exchange-rate.service';
+import { Cache } from 'cache-manager';
+
+describe('ExchangeRateService', () => {
+  let service: ExchangeRateService;
+  let mockCacheManager: jest.Mocked<Cache>;
+  let mockConfigService: jest.Mocked<ConfigService>;
+
+  beforeEach(async () => {
+    mockCacheManager = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+    } as any;
+
+    mockConfigService = {
+      get: jest.fn().mockReturnValue('https://api.example.com/rates'),
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExchangeRateService,
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ExchangeRateService>(ExchangeRateService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getRates', () => {
+    it('should return cached rates if available', async () => {
+      const cachedData = {
+        rates: { EUR: 0.92, GBP: 0.79 },
+        lastUpdated: new Date(),
+        source: 'api',
+      };
+
+      mockCacheManager.get.mockResolvedValue(cachedData);
+
+      const result = await service.getRates();
+
+      expect(result.base).toBe('USD');
+      expect(result.rates).toEqual(cachedData.rates);
+      expect(result.source).toBe('api');
+    });
+
+    it('should return fallback rates when cache is empty and fetch fails', async () => {
+      mockCacheManager.get.mockResolvedValue(null);
+      mockCacheManager.set.mockResolvedValue(undefined);
+
+      // Mock fetch to fail
+      const result = await service.getRates();
+
+      expect(result.base).toBe('USD');
+      expect(result.source).toBe('fallback');
+      expect(result.rates).toBeDefined();
+    });
+  });
+
+  describe('getRate', () => {
+    it('should return specific currency rate', async () => {
+      const cachedData = {
+        rates: { EUR: 0.92, GBP: 0.79 },
+        lastUpdated: new Date(),
+        source: 'api',
+      };
+
+      mockCacheManager.get.mockResolvedValue(cachedData);
+
+      const rate = await service.getRate('EUR');
+
+      expect(rate).toBe(0.92);
+    });
+
+    it('should return null for unknown currency', async () => {
+      const cachedData = {
+        rates: { EUR: 0.92, GBP: 0.79 },
+        lastUpdated: new Date(),
+        source: 'api',
+      };
+
+      mockCacheManager.get.mockResolvedValue(cachedData);
+
+      const rate = await service.getRate('XXX');
+
+      expect(rate).toBeNull();
+    });
+  });
+
+  describe('refresh', () => {
+    it('should clear cache and fetch fresh rates', async () => {
+      mockCacheManager.del.mockResolvedValue(undefined);
+      mockCacheManager.set.mockResolvedValue(undefined);
+
+      const result = await service.refresh();
+
+      expect(mockCacheManager.del).toHaveBeenCalled();
+      expect(result.base).toBe('USD');
+    });
+  });
+
+  describe('getHealth', () => {
+    it('should return healthy status when cache is available', async () => {
+      const cachedData = {
+        rates: { EUR: 0.92 },
+        lastUpdated: new Date(),
+        source: 'api',
+      };
+
+      mockCacheManager.get.mockResolvedValue(cachedData);
+
+      const health = await service.getHealth();
+
+      expect(health.status).toBe('healthy');
+      expect(health.source).toBe('api');
+    });
+
+    it('should return unhealthy status when no cache and no last update', async () => {
+      mockCacheManager.get.mockResolvedValue(null);
+
+      const health = await service.getHealth();
+
+      expect(health.status).toBe('unhealthy');
+    });
+  });
+});

--- a/src/exchange-rate/exchange-rate.service.ts
+++ b/src/exchange-rate/exchange-rate.service.ts
@@ -1,0 +1,239 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject } from '@nestjs/common';
+import { Cache } from 'cache-manager';
+import axios, { AxiosInstance } from 'axios';
+import { ExchangeRateResponseDto, CachedExchangeRate } from './dto/exchange-rate.dto';
+
+const CACHE_KEY = 'exchange_rates_usd';
+const CACHE_TTL = 3600; // 1 hour in seconds
+const FALLBACK_RATES: Record<string, number> = {
+  EUR: 0.92,
+  GBP: 0.79,
+  JPY: 149.50,
+  CAD: 1.36,
+  AUD: 1.53,
+  CHF: 0.88,
+  CNY: 7.24,
+  INR: 83.12,
+  MXN: 17.15,
+  BRL: 4.97,
+};
+
+@Injectable()
+export class ExchangeRateService implements OnModuleInit {
+  private readonly logger = new Logger(ExchangeRateService.name);
+  private readonly axiosInstance: AxiosInstance;
+  private readonly exchangeRateUrl: string;
+  private lastError: string | null = null;
+  private lastSuccessfulUpdate: Date | null = null;
+
+  constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    private configService: ConfigService,
+  ) {
+    this.exchangeRateUrl = this.configService.get<string>('EXCHANGE_RATE_URL') || '';
+    
+    this.axiosInstance = axios.create({
+      timeout: 10000, // 10 second timeout
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+  }
+
+  async onModuleInit() {
+    // Pre-warm cache on startup
+    try {
+      await this.fetchAndCacheRates();
+      this.logger.log('Exchange rates initialized successfully');
+    } catch (error) {
+      this.logger.warn('Failed to initialize exchange rates, will use fallback');
+    }
+  }
+
+  /**
+   * Get current exchange rates
+   * Returns cached rates if available, otherwise fetches fresh
+   */
+  async getRates(): Promise<ExchangeRateResponseDto> {
+    // Try to get from cache first
+    const cached = await this.cacheManager.get<CachedExchangeRate>(CACHE_KEY);
+    
+    if (cached) {
+      return {
+        base: 'USD',
+        rates: cached.rates,
+        lastUpdated: cached.lastUpdated,
+        source: cached.source,
+      };
+    }
+
+    // Cache miss - fetch fresh rates
+    try {
+      const freshRates = await this.fetchAndCacheRates();
+      return {
+        base: 'USD',
+        rates: freshRates.rates,
+        lastUpdated: freshRates.lastUpdated,
+        source: freshRates.source,
+      };
+    } catch (error) {
+      this.logger.error('Failed to fetch exchange rates', error);
+      this.lastError = error instanceof Error ? error.message : 'Unknown error';
+      
+      // Return fallback rates
+      return {
+        base: 'USD',
+        rates: FALLBACK_RATES,
+        lastUpdated: this.lastSuccessfulUpdate || new Date(),
+        source: 'fallback',
+      };
+    }
+  }
+
+  /**
+   * Get specific currency rate
+   */
+  async getRate(currency: string): Promise<number | null> {
+    const { rates } = await this.getRates();
+    return rates[currency.toUpperCase()] ?? null;
+  }
+
+  /**
+   * Force refresh the exchange rates
+   */
+  async refresh(): Promise<ExchangeRateResponseDto> {
+    this.logger.log('Force refreshing exchange rates');
+    
+    // Clear cache
+    await this.cacheManager.del(CACHE_KEY);
+    
+    // Fetch fresh
+    const freshRates = await this.fetchAndCacheRates();
+    
+    return {
+      base: 'USD',
+      rates: freshRates.rates,
+      lastUpdated: freshRates.lastUpdated,
+      source: freshRates.source,
+    };
+  }
+
+  /**
+   * Get service health status
+   */
+  async getHealth(): Promise<{
+    status: 'healthy' | 'degraded' | 'unhealthy';
+    lastUpdate: Date | null;
+    lastError: string | null;
+    source: string;
+  }> {
+    const cached = await this.cacheManager.get<CachedExchangeRate>(CACHE_KEY);
+    
+    let status: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
+    
+    if (!cached && !this.lastSuccessfulUpdate) {
+      status = 'unhealthy';
+    } else if (this.lastError && !cached) {
+      status = 'degraded';
+    }
+    
+    return {
+      status,
+      lastUpdate: this.lastSuccessfulUpdate,
+      lastError: this.lastError,
+      source: cached?.source || 'none',
+    };
+  }
+
+  /**
+   * Fetch rates from external API and cache them
+   */
+  private async fetchAndCacheRates(): Promise<CachedExchangeRate> {
+    if (!this.exchangeRateUrl) {
+      this.logger.warn('EXCHANGE_RATE_URL not configured, using fallback rates');
+      const fallbackData: CachedExchangeRate = {
+        rates: FALLBACK_RATES,
+        lastUpdated: new Date(),
+        source: 'fallback',
+      };
+      await this.cacheManager.set(CACHE_KEY, fallbackData, CACHE_TTL * 1000);
+      return fallbackData;
+    }
+
+    try {
+      const response = await this.axiosInstance.get(this.exchangeRateUrl);
+      const rates = this.parseRates(response.data);
+      
+      const cachedData: CachedExchangeRate = {
+        rates,
+        lastUpdated: new Date(),
+        source: 'api',
+      };
+      
+      // Cache for 1 hour
+      await this.cacheManager.set(CACHE_KEY, cachedData, CACHE_TTL * 1000);
+      
+      this.lastSuccessfulUpdate = new Date();
+      this.lastError = null;
+      
+      this.logger.debug('Exchange rates cached successfully');
+      return cachedData;
+    } catch (error) {
+      this.lastError = error instanceof Error ? error.message : 'Unknown error';
+      
+      // If we have previous cached data, extend its TTL and use it
+      const existingCache = await this.cacheManager.get<CachedExchangeRate>(CACHE_KEY);
+      if (existingCache) {
+        this.logger.warn('Using cached rates due to fetch error');
+        await this.cacheManager.set(CACHE_KEY, existingCache, CACHE_TTL * 1000);
+        return existingCache;
+      }
+      
+      // No cache available - use fallback
+      this.logger.warn('Using fallback rates due to fetch error');
+      const fallbackData: CachedExchangeRate = {
+        rates: FALLBACK_RATES,
+        lastUpdated: new Date(),
+        source: 'fallback',
+      };
+      await this.cacheManager.set(CACHE_KEY, fallbackData, CACHE_TTL * 1000);
+      return fallbackData;
+    }
+  }
+
+  /**
+   * Parse rates from API response
+   * Handles multiple common response formats
+   */
+  private parseRates(data: any): Record<string, number> {
+    // Format 1: { rates: { EUR: 0.92, ... } }
+    if (data.rates && typeof data.rates === 'object') {
+      return data.rates;
+    }
+    
+    // Format 2: { data: { EUR: 0.92, ... } }
+    if (data.data && typeof data.data === 'object') {
+      return data.data;
+    }
+    
+    // Format 3: { EUR: 0.92, GBP: 0.79, ... }
+    if (typeof data === 'object' && !Array.isArray(data)) {
+      const rates: Record<string, number> = {};
+      for (const [key, value] of Object.entries(data)) {
+        if (typeof value === 'number') {
+          rates[key.toUpperCase()] = value;
+        }
+      }
+      if (Object.keys(rates).length > 0) {
+        return rates;
+      }
+    }
+    
+    throw new Error('Unable to parse exchange rates from API response');
+  }
+}

--- a/src/exchange-rate/index.ts
+++ b/src/exchange-rate/index.ts
@@ -1,0 +1,4 @@
+export * from './exchange-rate.module';
+export * from './exchange-rate.service';
+export * from './exchange-rate.controller';
+export * from './dto/exchange-rate.dto';


### PR DESCRIPTION
## Summary

Implements **Issue #205** - Exchange Rate Service

### Features

- **Fetches USD exchange rates** from configurable `EXCHANGE_RATE_URL`
- **1-hour cache TTL** using Redis-backed cache
- **Fallback rates** when API is unavailable
- **Graceful error handling** with automatic degradation
- **Health check endpoint** for monitoring

### New Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/exchange-rate` | All USD exchange rates |
| `GET /api/exchange-rate/rate?currency=EUR` | Specific currency rate |
| `GET /api/exchange-rate/refresh` | Force refresh rates |
| `GET /api/exchange-rate/health` | Service health status |

### Configuration

```env
EXCHANGE_RATE_URL=https://api.example.com/rates
```

### Error Handling

1. **Cache hit** → Return cached rates
2. **Cache miss + API success** → Fetch, cache, return
3. **Cache miss + API fail** → Return fallback rates
4. **API fail + cached data** → Extend cache TTL, return cached

### Fallback Rates

Built-in fallback rates for major currencies:
- EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, MXN, BRL

### Files Added

```
src/exchange-rate/
├── dto/
│   └── exchange-rate.dto.ts      # Response DTOs
├── exchange-rate.module.ts       # Module definition
├── exchange-rate.service.ts      # Core service with caching
├── exchange-rate.controller.ts   # REST endpoints
├── exchange-rate.service.spec.ts # Unit tests
└── index.ts                      # Exports
```

### Testing

- Unit tests included for all service methods
- Tests cover: cache hit/miss, fallback, refresh, health check

### Bounty

This PR addresses bounty issue #205.