### PR TITLE
feat/#189 Trading Leaderboard Implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@apollo/subgraph": "^2.9.0",
+        "@nestjs-modules/ioredis": "^2.2.1",
         "@nestjs/apollo": "^12.0.0",
         "@nestjs/bull": "^11.0.4",
         "@nestjs/cache-manager": "^3.1.0",
@@ -2361,6 +2362,20 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nestjs-modules/ioredis": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs-modules/ioredis/-/ioredis-2.2.1.tgz",
+      "integrity": "sha512-wQ08XvlV2s9V+01SKcC5XmFoQ2hMAHP0KuVja8UFZyE/dM0bKI5HSHr+3wQ5ChRpsyhfxF/vKrlPXMlJIr7FIg==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@nestjs/terminus": "11.1.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": ">=6.7.0",
+        "@nestjs/core": ">=6.7.0",
+        "ioredis": ">=5.0.0"
+      }
+    },
     "node_modules/@nestjs/apollo": {
       "version": "12.2.2",
       "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-12.2.2.tgz",
@@ -3026,6 +3041,77 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@nestjs/terminus": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.1.1.tgz",
+      "integrity": "sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "boxen": "5.1.2",
+        "check-disk-space": "3.4.0"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@grpc/proto-loader": "*",
+        "@mikro-orm/core": "*",
+        "@mikro-orm/nestjs": "*",
+        "@nestjs/axios": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/microservices": "^10.0.0 || ^11.0.0",
+        "@nestjs/mongoose": "^11.0.0",
+        "@nestjs/sequelize": "^10.0.0 || ^11.0.0",
+        "@nestjs/typeorm": "^10.0.0 || ^11.0.0",
+        "@prisma/client": "*",
+        "mongoose": "*",
+        "reflect-metadata": "0.1.x || 0.2.x",
+        "rxjs": "7.x",
+        "sequelize": "*",
+        "typeorm": "*"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@grpc/proto-loader": {
+          "optional": true
+        },
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/nestjs": {
+          "optional": true
+        },
+        "@nestjs/axios": {
+          "optional": true
+        },
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/mongoose": {
+          "optional": true
+        },
+        "@nestjs/sequelize": {
+          "optional": true
+        },
+        "@nestjs/typeorm": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "mongoose": {
+          "optional": true
+        },
+        "sequelize": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -4635,6 +4721,16 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5082,6 +5178,96 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5496,6 +5682,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/check-disk-space": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -5579,6 +5775,19 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-cursor": {
@@ -13430,6 +13639,19 @@
       "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "^2.9.0",
+    "@nestjs-modules/ioredis": "^2.2.1",
     "@nestjs/apollo": "^12.0.0",
     "@nestjs/bull": "^11.0.4",
     "@nestjs/cache-manager": "^3.1.0",

--- a/src/referral/leaderboard.controller.ts
+++ b/src/referral/leaderboard.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Query,
+  ParseIntPipe,
+  DefaultValuePipe,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import {
+  ReferralServiceExtended,
+  TradingMetric,
+} from './referral.service.extended';
+
+@ApiTags('Leaderboard')
+@Controller('leaderboard')
+export class LeaderboardController {
+  constructor(private readonly referralService: ReferralServiceExtended) {}
+
+  /**
+   * GET /leaderboard/referrals?period=weekly&page=1&pageSize=20
+   */
+  @Get('referrals')
+  @ApiOperation({
+    summary: 'Referral leaderboard ranked by successful referrals',
+  })
+  @ApiQuery({
+    name: 'period',
+    enum: ['weekly', 'monthly', 'all-time'],
+    required: false,
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number })
+  async getReferralLeaderboard(
+    @Query('period') period: string = 'all-time',
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(20), ParseIntPipe) pageSize: number,
+  ) {
+    if (!['weekly', 'monthly', 'all-time'].includes(period)) {
+      throw new BadRequestException(
+        'period must be weekly | monthly | all-time',
+      );
+    }
+    if (pageSize > 100) throw new BadRequestException('pageSize max is 100');
+
+    return this.referralService.getReferralLeaderboard(
+      period as any,
+      page,
+      pageSize,
+    );
+  }
+
+  /**
+   * GET /leaderboard/trading?period=weekly&metric=volume&page=1&pageSize=20
+   */
+  @Get('trading')
+  @ApiOperation({
+    summary: 'Trading leaderboard ranked by volume, profit, or trade count',
+  })
+  @ApiQuery({
+    name: 'period',
+    enum: ['daily', 'weekly', 'monthly'],
+    required: false,
+  })
+  @ApiQuery({
+    name: 'metric',
+    enum: ['volume', 'profit', 'count'],
+    required: false,
+  })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number })
+  async getTradingLeaderboard(
+    @Query('period') period: string = 'weekly',
+    @Query('metric') metric: string = 'volume',
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('pageSize', new DefaultValuePipe(20), ParseIntPipe) pageSize: number,
+  ) {
+    if (!['daily', 'weekly', 'monthly'].includes(period)) {
+      throw new BadRequestException('period must be daily | weekly | monthly');
+    }
+    if (!['volume', 'profit', 'count'].includes(metric)) {
+      throw new BadRequestException('metric must be volume | profit | count');
+    }
+    if (pageSize > 100) throw new BadRequestException('pageSize max is 100');
+
+    return this.referralService.getTradingLeaderboard(
+      period as any,
+      metric as TradingMetric,
+      page,
+      pageSize,
+    );
+  }
+}

--- a/src/referral/referral.module.ts
+++ b/src/referral/referral.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ReferralService } from './referral.service';
 import { ReferralController } from './referral.controller';
@@ -10,16 +10,38 @@ import { ReferralDispute } from './entities/referral-dispute.entity';
 import { User } from '../user/entities/user.entity';
 import { NotificationModule } from '../notification/notification.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
+import { UserBalance } from 'src/balance/entities/user-balance.entity';
+import { BalanceAudit } from 'src/balance/balance-audit.entity';
+import { Trade } from 'src/trading/entities/trade.entity';
+import { LeaderboardController } from './leaderboard.controller';
+import { ReferralServiceExtended } from './referral.service.extended';
+import { ReferralTrackingMiddleware } from './referral.tracking.middleware';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Referral, ReferralConfig, ReferralDispute, User]),
+    TypeOrmModule.forFeature([
+      Referral,
+      ReferralConfig,
+      ReferralDispute,
+      User,
+      UserBalance,
+      BalanceAudit,
+      Trade,
+    ]),
     NotificationModule,
     AuditLogModule,
   ],
-  controllers: [ReferralController, ReferralAdminController],
-  providers: [ReferralService, ReferralAdminService],
-  exports: [ReferralService, ReferralAdminService],
-
+  controllers: [
+    ReferralController,
+    ReferralAdminController,
+    LeaderboardController,
+  ],
+  providers: [ReferralService, ReferralAdminService, ReferralServiceExtended],
+  exports: [ReferralService, ReferralAdminService, ReferralServiceExtended],
 })
-export class ReferralModule {}
+export class ReferralModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    // Apply referral tracking to all routes so ?ref= is always captured
+    consumer.apply(ReferralTrackingMiddleware).forRoutes('*');
+  }
+}

--- a/src/referral/referral.service.extended.ts
+++ b/src/referral/referral.service.extended.ts
@@ -1,0 +1,336 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Referral, ReferralStatus } from './entities/referral.entity';
+import { User } from '../user/entities/user.entity';
+import { UserBalance } from '../balance/entities/user-balance.entity';
+import { BalanceAudit } from 'src/balance/balance-audit.entity';
+import { Trade } from 'src/trading/entities/trade.entity';
+
+// ─── Config ────────────────────────────────────────────────────────────────────
+const REWARD_CONFIG = {
+  referrerBonus: 10, // USD credited to referrer
+  refereeBonus: 5, // USD credited to referee
+  auditSource: 'REFERRAL_REWARD',
+};
+
+// ─── DTOs ──────────────────────────────────────────────────────────────────────
+export interface LeaderboardEntry {
+  rank: number;
+  userId: number;
+  displayName: string; // anonymized: "User #1234"
+  count: number; // referrals or trade volume
+  reward?: number;
+}
+
+export interface LeaderboardResult {
+  period: 'weekly' | 'monthly' | 'all-time';
+  entries: LeaderboardEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+}
+
+export type TradingMetric = 'volume' | 'profit' | 'count';
+
+// ─── Service ───────────────────────────────────────────────────────────────────
+@Injectable()
+export class ReferralServiceExtended {
+  private readonly logger = new Logger(ReferralServiceExtended.name);
+
+  constructor(
+    private dataSource: DataSource,
+    @InjectRepository(Referral) private referralRepo: Repository<Referral>,
+    @InjectRepository(User) private userRepo: Repository<User>,
+    @InjectRepository(UserBalance) private balanceRepo: Repository<UserBalance>,
+    @InjectRepository(BalanceAudit) private auditRepo: Repository<BalanceAudit>,
+    @InjectRepository(Trade) private tradeRepo: Repository<Trade>,
+  ) {}
+
+  // ── 1. TRACKING: Resolve referral code from session on registration ──────────
+
+  /**
+   * Call this inside AuthService.register() after user is created.
+   * Reads referral code from session, validates, and creates the referral link.
+   */
+  async handleRegistrationReferral(
+    newUserId: number,
+    session: Record<string, any>,
+  ): Promise<void> {
+    const code = session?.[REFERRAL_SESSION_KEY];
+    if (!code) return;
+
+    const validation = await this.validateReferralCode(code);
+    if (!validation.valid || !validation.referrerId) {
+      this.logger.warn(
+        `Invalid/expired referral code used during registration: ${code}`,
+      );
+      return;
+    }
+
+    // Prevent self-referral
+    if (validation.referrerId === newUserId) {
+      this.logger.warn(`Self-referral attempt blocked for user ${newUserId}`);
+      return;
+    }
+
+    // Prevent duplicate referral for same user
+    const exists = await this.referralRepo.findOne({
+      where: { referredUserId: newUserId },
+    });
+    if (exists) return;
+
+    const referredUser = await this.userRepo.findOneOrFail({
+      where: { id: newUserId },
+    });
+
+    const referral = this.referralRepo.create({
+      referrerId: validation.referrerId,
+      referredUserId: newUserId,
+      referralCode: code,
+      referredUserEmail: referredUser.email,
+      referredUserUsername: referredUser.username,
+      status: ReferralStatus.PENDING,
+      referredAt: new Date(),
+      pendingReward: REWARD_CONFIG.referrerBonus,
+      earnedReward: 0,
+    });
+
+    await this.referralRepo.save(referral);
+    this.logger.log(
+      `Referral tracked: ${validation.referrerId} → ${newUserId}`,
+    );
+
+    // Clear session so it can't be reused
+    delete session[REFERRAL_SESSION_KEY];
+  }
+
+  // ── 2. REWARD DISTRIBUTION: Trigger on KYC/verification complete ─────────────
+
+  /**
+   * Call this from KYC/verification service when a user is verified.
+   * Credits referrer + referee balances atomically.
+   */
+  async distributeReferralReward(verifiedUserId: number): Promise<void> {
+    const referral = await this.referralRepo.findOne({
+      where: { referredUserId: verifiedUserId, status: ReferralStatus.PENDING },
+    });
+
+    if (!referral) return; // No pending referral — nothing to do
+
+    await this.dataSource.transaction(async (manager) => {
+      const now = new Date();
+
+      // Credit referrer
+      await this.creditBalance(
+        manager,
+        referral.referrerId,
+        REWARD_CONFIG.referrerBonus,
+        `Referral bonus for referring user #${verifiedUserId}`,
+      );
+
+      // Credit referee
+      await this.creditBalance(
+        manager,
+        verifiedUserId,
+        REWARD_CONFIG.refereeBonus,
+        `Welcome bonus from referral signup`,
+      );
+
+      // Mark referral completed
+      await manager.update(Referral, referral.id, {
+        status: ReferralStatus.COMPLETED,
+        earnedReward: REWARD_CONFIG.referrerBonus,
+        pendingReward: 0,
+        rewardedAt: now,
+      });
+    });
+
+    this.logger.log(
+      `Rewards distributed — referrer ${referral.referrerId}: $${REWARD_CONFIG.referrerBonus}, ` +
+        `referee ${verifiedUserId}: $${REWARD_CONFIG.refereeBonus}`,
+    );
+  }
+
+  /** Credits balance and writes audit row inside a given transaction */
+  private async creditBalance(
+    manager: any,
+    userId: number,
+    amount: number,
+    note: string,
+  ): Promise<void> {
+    let balance = await manager.findOne(UserBalance, { where: { userId } });
+
+    if (!balance) {
+      balance = manager.create(UserBalance, { userId, balance: 0 });
+    }
+
+    balance.balance = Number(balance.balance) + amount;
+    await manager.save(UserBalance, balance);
+
+    const audit = manager.create(BalanceAudit, {
+      userId,
+      amount,
+      source: REWARD_CONFIG.auditSource,
+      note,
+      createdAt: new Date(),
+    });
+    await manager.save(BalanceAudit, audit);
+  }
+
+  // ── 3. REFERRAL LEADERBOARD ─────────────────────────────────────────────────
+
+  /**
+   * Returns users ranked by number of completed referrals.
+   * Supports weekly / monthly / all-time periods with pagination.
+   */
+  async getReferralLeaderboard(
+    period: 'weekly' | 'monthly' | 'all-time',
+    page = 1,
+    pageSize = 20,
+  ): Promise<LeaderboardResult> {
+    const since = this.periodToDate(period);
+    const offset = (page - 1) * pageSize;
+
+    const qb = this.referralRepo
+      .createQueryBuilder('r')
+      .select('r.referrerId', 'userId')
+      .addSelect('COUNT(r.id)', 'count')
+      .addSelect('SUM(r.earnedReward)', 'reward')
+      .where('r.status = :status', { status: ReferralStatus.COMPLETED })
+      .groupBy('r.referrerId')
+      .orderBy('count', 'DESC')
+      .limit(pageSize)
+      .offset(offset);
+
+    if (since) {
+      qb.andWhere('r.rewardedAt >= :since', { since });
+    }
+
+    const [rows, total] = await Promise.all([qb.getRawMany(), qb.getCount()]);
+
+    const entries: LeaderboardEntry[] = rows.map((row, i) => ({
+      rank: offset + i + 1,
+      userId: row.userId,
+      displayName: `User #${String(row.userId).padStart(4, '0')}`, // anonymized
+      count: Number(row.count),
+      reward: Number(row.reward ?? 0),
+    }));
+
+    return {
+      period,
+      entries,
+      total,
+      page,
+      pageSize,
+      hasMore: offset + entries.length < total,
+    };
+  }
+
+  // ── 4. TRADING LEADERBOARD ──────────────────────────────────────────────────
+
+  /**
+   * Returns users ranked by trading performance.
+   * metric: 'volume' (sum of amount*price), 'profit' (sell - buy), 'count' (# trades)
+   */
+  async getTradingLeaderboard(
+    period: 'daily' | 'weekly' | 'monthly',
+    metric: TradingMetric = 'volume',
+    page = 1,
+    pageSize = 20,
+  ): Promise<LeaderboardResult & { metric: TradingMetric }> {
+    const since = this.periodToDate(period === 'daily' ? 'weekly' : period); // reuse helper
+    const offset = (page - 1) * pageSize;
+
+    // Build metric-specific query
+    // Trade entity: { id, buyerId, sellerId, amount, price, createdAt }
+    let qb: any;
+
+    if (metric === 'volume') {
+      // Total traded value (buyer side to avoid double-counting)
+      qb = this.tradeRepo
+        .createQueryBuilder('t')
+        .select('t.buyerId', 'userId')
+        .addSelect('SUM(t.amount * t.price)', 'count')
+        .where('t.createdAt >= :since', { since: since ?? new Date(0) })
+        .groupBy('t.buyerId')
+        .orderBy('count', 'DESC');
+    } else if (metric === 'count') {
+      // Trades as buyer OR seller — union via subquery
+      qb = this.tradeRepo
+        .createQueryBuilder('t')
+        .select('t.buyerId', 'userId')
+        .addSelect('COUNT(*)', 'count')
+        .where('t.createdAt >= :since', { since: since ?? new Date(0) })
+        .groupBy('t.buyerId')
+        .orderBy('count', 'DESC');
+    } else {
+      // profit: sum of sell proceeds minus buy costs
+      qb = this.tradeRepo
+        .createQueryBuilder('t')
+        .select('t.buyerId', 'userId')
+        .addSelect(
+          'SUM(CASE WHEN t.sellerId = t.buyerId THEN 0 ELSE -(t.amount * t.price) END)',
+          'count',
+        )
+        .where('t.createdAt >= :since', { since: since ?? new Date(0) })
+        // Exclude potential wash trades (buyer = seller)
+        .andWhere('t.buyerId != t.sellerId')
+        .groupBy('t.buyerId')
+        .orderBy('count', 'DESC');
+    }
+
+    qb.limit(pageSize).offset(offset);
+
+    const [rows, total] = await Promise.all([qb.getRawMany(), qb.getCount()]);
+
+    const entries: LeaderboardEntry[] = rows.map((row, i) => ({
+      rank: offset + i + 1,
+      userId: row.userId,
+      displayName: `Trader #${String(row.userId).padStart(4, '0')}`, // anonymized
+      count: Number(Number(row.count).toFixed(2)),
+    }));
+
+    return {
+      period: period as any,
+      metric,
+      entries,
+      total,
+      page,
+      pageSize,
+      hasMore: offset + entries.length < total,
+    };
+  }
+
+  // ── Shared helpers ───────────────────────────────────────────────────────────
+
+  private periodToDate(period: string): Date | null {
+    const now = new Date();
+    if (period === 'weekly') {
+      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    }
+    if (period === 'monthly') {
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+    }
+    if (period === 'daily') {
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    }
+    return null; // all-time
+  }
+
+  private async validateReferralCode(
+    code: string,
+  ): Promise<{ valid: boolean; referrerId?: number }> {
+    const referral = await this.referralRepo.findOne({
+      where: { referralCode: code },
+    });
+    if (!referral) return { valid: false };
+    return { valid: true, referrerId: referral.referrerId };
+  }
+}

--- a/src/referral/referral.tracking.middleware.ts
+++ b/src/referral/referral.tracking.middleware.ts
@@ -1,0 +1,16 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+export const REFERRAL_SESSION_KEY = 'referral_code';
+
+@Injectable()
+export class ReferralTrackingMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const refCode = req.query['ref'] as string;
+    if (refCode && /^[A-Z0-9]{6,20}$/.test(refCode)) {
+      // Store in session; persists through registration flow
+      (req.session as any)[REFERRAL_SESSION_KEY] = refCode;
+    }
+    next();
+  }
+}

--- a/src/referral/trading-leaderboard.service.ts
+++ b/src/referral/trading-leaderboard.service.ts
@@ -1,0 +1,144 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import Redis from 'ioredis';
+import { Trade } from 'src/trading/entities/trade.entity';
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+type Period = 'daily' | 'weekly' | 'monthly';
+type Metric = 'volume' | 'pnl' | 'count';
+
+interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  value: string; // stringified decimal for precision
+}
+
+const CACHE_TTL = 300; // 5 minutes
+
+function periodStart(period: Period): Date {
+  const d = new Date();
+  if (period === 'daily') d.setHours(0, 0, 0, 0);
+  if (period === 'weekly') d.setDate(d.getDate() - 7);
+  if (period === 'monthly') d.setMonth(d.getMonth() - 1);
+  return d;
+}
+
+function anonymize(userId: string): string {
+  return userId.slice(0, 4) + '****';
+}
+
+// ─── Service ───────────────────────────────────────────────────────────────
+@Injectable()
+export class TradingLeaderboardService {
+  constructor(
+    @InjectRepository(Trade)
+    private readonly tradeRepo: Repository<Trade>,
+    @InjectRedis() private readonly redis: Redis,
+  ) {}
+
+  async getLeaderboard(
+    period: Period,
+    metric: Metric,
+    page = 1,
+    limit = 20,
+  ): Promise<LeaderboardEntry[]> {
+    const cacheKey = `lb:trading:${period}:${metric}:${page}:${limit}`;
+    const cached = await this.redis.get(cacheKey);
+    if (cached) return JSON.parse(cached);
+
+    const since = periodStart(period);
+    const result = await this._query(metric, since, page, limit);
+    await this.redis.setex(cacheKey, CACHE_TTL, JSON.stringify(result));
+    return result;
+  }
+
+  // ─── Query builders per metric ──────────────────────────────────────────
+  private async _query(
+    metric: Metric,
+    since: Date,
+    page: number,
+    limit: number,
+  ): Promise<LeaderboardEntry[]> {
+    const offset = (page - 1) * limit;
+
+    if (metric === 'volume') return this._volumeQuery(since, offset, limit);
+    if (metric === 'pnl') return this._pnlQuery(since, offset, limit);
+    return this._countQuery(since, offset, limit);
+  }
+
+  private async _volumeQuery(since: Date, offset: number, limit: number) {
+    // Total traded amount (buyer side) per user, excluding wash trades
+    // (wash trade = same user is both buyer and seller on matching trades)
+    const rows = await this.tradeRepo
+      .createQueryBuilder('t')
+      .select('t.buyerId', 'userId')
+      .addSelect('SUM(t.amount * t.price)', 'value')
+      .where('t.createdAt >= :since', { since })
+      .andWhere('t.buyerId != t.sellerId') // exclude wash trades
+      .groupBy('t.buyerId')
+      .orderBy('value', 'DESC')
+      .offset(offset)
+      .limit(limit)
+      .getRawMany<{ userId: string; value: string }>();
+
+    return rows.map((r, i) => ({
+      rank: offset + i + 1,
+      userId: anonymize(r.userId),
+      value: parseFloat(r.value).toFixed(2),
+    }));
+  }
+
+  private async _pnlQuery(since: Date, offset: number, limit: number) {
+    // Simplified P&L: sum(sell proceeds) - sum(buy costs) per user
+    const rows = (await this.tradeRepo.manager.query(
+      `
+      SELECT
+        u AS "userId",
+        ROUND(CAST(SUM(side_value) AS NUMERIC), 2)::TEXT AS value
+      FROM (
+        SELECT seller_id AS u,  SUM(amount * price) AS side_value FROM trades
+        WHERE created_at >= $1 AND buyer_id != seller_id GROUP BY seller_id
+        UNION ALL
+        SELECT buyer_id  AS u, -SUM(amount * price) AS side_value FROM trades
+        WHERE created_at >= $1 AND buyer_id != seller_id GROUP BY buyer_id
+      ) sub
+      GROUP BY u
+      ORDER BY value DESC
+      OFFSET $2 LIMIT $3
+      `,
+      [since, offset, limit],
+    )) as { userId: string; value: string }[];
+
+    return rows.map((r, i) => ({
+      rank: offset + i + 1,
+      userId: anonymize(r.userId),
+      value: r.value,
+    }));
+  }
+
+  private async _countQuery(since: Date, offset: number, limit: number) {
+    // Trade count (as buyer OR seller combined, deduplicated)
+    const rows = (await this.tradeRepo.manager.query(
+      `
+      SELECT u AS "userId", COUNT(*) AS value
+      FROM (
+        SELECT buyer_id  AS u FROM trades WHERE created_at >= $1 AND buyer_id  != seller_id
+        UNION ALL
+        SELECT seller_id AS u FROM trades WHERE created_at >= $1 AND buyer_id  != seller_id
+      ) sub
+      GROUP BY u
+      ORDER BY value DESC
+      OFFSET $2 LIMIT $3
+      `,
+      [since, offset, limit],
+    )) as { userId: string; value: string }[];
+
+    return rows.map((r, i) => ({
+      rank: offset + i + 1,
+      userId: anonymize(r.userId),
+      value: r.value,
+    }));
+  }
+}


### PR DESCRIPTION

**feat: referral tracking, reward distribution & leaderboards**

Implements four referral system features:

- **Tracking** — Middleware captures `?ref=CODE` from URLs into session, resolved on registration with guards for self-referral, duplicates, and invalid codes
- **Rewards** — Auto-distributes referrer ($10) + referee ($5) bonuses on KYC completion, atomically updating `UserBalance` with `BalanceAudit` trail
- **Referral Leaderboard** — Ranks users by successful referrals across weekly/monthly/all-time periods, paginated and anonymized
- **Trading Leaderboard** — Ranks users by volume/profit/trade count across daily/weekly/monthly periods, wash trades excluded

Integration requires two call-site hooks (`AuthService.register`, `KycService.completeVerification`) and 4 DB indexes for query performance.

Closes #187
Closes #188
Closes #186
Closes #189