### PR TITLE
feat: admin API, referral tracking, leaderboard & fraud protection

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller, Get, Post, Patch, Param, Body, Query,
+  UseGuards, Request, ParseUUIDPipe, HttpCode, HttpStatus,
+} from '@nestjs/common';
+import { Throttle }           from '@nestjs/throttler';
+import { AdminGuard }         from '../common/guards/admin.guard';
+import { AdminService }       from './admin.service';
+import { WaitlistService }    from '../waitlist/waitlist.service';
+import { WaitlistQueryDto }   from '../waitlist/dto/waitlist-query.dto';
+import { PatchWaitlistStatusDto } from '../waitlist/dto/patch-waitlist-status.dto';
+import { AdjustPointsDto }    from './dto/adjust-points.dto';
+import { ReferralQueryDto }   from './dto/referral-query.dto';
+
+@Controller('admin')
+@UseGuards(AdminGuard)
+@Throttle({ default: { limit: 30, ttl: 60000 } })
+export class AdminController {
+  constructor(
+    private readonly adminService: AdminService,
+    private readonly waitlistService: WaitlistService,
+  ) {}
+
+  // #201 GET /admin/waitlist
+  @Get('waitlist')
+  getWaitlist(@Query() query: WaitlistQueryDto) {
+    return this.waitlistService.findAll(query);
+  }
+
+  // #201 GET /admin/referrals
+  @Get('referrals')
+  getReferrals(@Query() query: ReferralQueryDto) {
+    return this.adminService.getReferrals(query);
+  }
+
+  // #201 POST /admin/waitlist/:id/invite
+  @Post('waitlist/:id/invite')
+  @HttpCode(HttpStatus.OK)
+  async invite(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req: any,
+  ) {
+    const result = await this.waitlistService.invite(id, req.user.id);
+    await this.adminService.auditEntry(req.user.id, 'invite', 'waitlist', id);
+    return result;
+  }
+
+  // #201 PATCH /admin/waitlist/:id/status
+  @Patch('waitlist/:id/status')
+  async patchStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: PatchWaitlistStatusDto,
+    @Request() req: any,
+  ) {
+    const result = await this.waitlistService.patchStatus(id, dto, req.user.id);
+    await this.adminService.auditEntry(req.user.id, 'patch_status', 'waitlist', id, dto);
+    return result;
+  }
+
+  // #201 POST /admin/referrals/:id/adjust
+  @Post('referrals/:id/adjust')
+  @HttpCode(HttpStatus.OK)
+  adjustPoints(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AdjustPointsDto,
+    @Request() req: any,
+  ) {
+    return this.adminService.adjustPoints(id, dto, req.user.id);
+  }
+}

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,62 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource }  from 'typeorm';
+import { AdjustPointsDto }         from './dto/adjust-points.dto';
+import { ReferralQueryDto }        from './dto/referral-query.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository('waitlist_referral_points')
+    private readonly pointsRepo: Repository<any>,
+    @InjectRepository('waitlist_referrals')
+    private readonly referralRepo: Repository<any>,
+    @InjectRepository('audit_log')
+    private readonly auditRepo: Repository<any>,
+  ) {}
+
+  // #201 — referrals list with filters
+  async getReferrals(query: ReferralQueryDto) {
+    const { status, suspect, page, limit } = query;
+    const qb = this.referralRepo.createQueryBuilder('r')
+      .orderBy('r.created_at', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (status)  qb.andWhere('r.status = :status', { status });
+    if (suspect) qb.andWhere('r.fraud_score >= :threshold', { threshold: 40 });
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  // #201 — manual point adjustment
+  async adjustPoints(referralId: string, dto: AdjustPointsDto, adminId: string): Promise<any> {
+    const referral = await this.referralRepo.findOne({ where: { id: referralId } });
+    if (!referral) throw new NotFoundException('Referral not found');
+
+    await this.pointsRepo.save(
+      this.pointsRepo.create({
+        user_id: referral.referrer_id,
+        points:  dto.delta,
+        reason:  dto.reason,
+      }),
+    );
+
+    await this.auditEntry(adminId, 'adjust_points', 'referral', referralId, dto);
+    return { success: true };
+  }
+
+  // #201 — shared audit logger
+  async auditEntry(
+    adminId: string,
+    action: string,
+    targetType: string,
+    targetId: string,
+    payload?: object,
+  ): Promise<void> {
+    await this.auditRepo.save(
+      this.auditRepo.create({ admin_id: adminId, action, target_type: targetType, target_id: targetId, payload }),
+    );
+  }
+}

--- a/src/admin/dto/adjust-points.dto.ts
+++ b/src/admin/dto/adjust-points.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsString, IsNotEmpty, Min, Max } from 'class-validator';
+
+export class AdjustPointsDto {
+  @IsInt()
+  @Min(-1000)
+  @Max(1000)
+  delta: number;
+
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/src/admin/dto/referral-query.dto.ts
+++ b/src/admin/dto/referral-query.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsEnum, IsBoolean, IsInt, Min, Max } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+
+export enum ReferralStatus {
+  PENDING   = 'pending',
+  CONFIRMED = 'confirmed',
+  FLAGGED   = 'flagged',
+  REJECTED  = 'rejected',
+}
+
+export class ReferralQueryDto {
+  @IsOptional()
+  @IsEnum(ReferralStatus)
+  status?: ReferralStatus;
+
+  @IsOptional()
+  @Transform(({ value }) => value === 'true')
+  @IsBoolean()
+  suspect?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+}

--- a/src/admin/tests/admin.service.spec.ts
+++ b/src/admin/tests/admin.service.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminService }        from '../admin.service';
+import { NotFoundException }   from '@nestjs/common';
+import { getRepositoryToken }  from '@nestjs/typeorm';
+
+const mockRepo = (overrides = {}) => ({
+  findOne:             jest.fn(),
+  save:                jest.fn(),
+  create:              jest.fn((x) => x),
+  createQueryBuilder:  jest.fn(() => ({
+    orderBy: jest.fn().mockReturnThis(),
+    skip:    jest.fn().mockReturnThis(),
+    take:    jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+  })),
+  ...overrides,
+});
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let referralRepo: any;
+  let auditRepo: any;
+
+  beforeEach(async () => {
+    referralRepo = mockRepo();
+    auditRepo    = mockRepo();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: getRepositoryToken('waitlist_referral_points'), useValue: mockRepo() },
+        { provide: getRepositoryToken('waitlist_referrals'),       useValue: referralRepo },
+        { provide: getRepositoryToken('audit_log'),                useValue: auditRepo  },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('throws if referral not found on adjust', async () => {
+    referralRepo.findOne.mockResolvedValueOnce(null);
+    await expect(
+      service.adjustPoints('bad-id', { delta: 5, reason: 'test' }, 'admin-1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('writes audit log on adjust', async () => {
+    referralRepo.findOne.mockResolvedValueOnce({ id: 'ref-1', referrer_id: 'user-1' });
+    await service.adjustPoints('ref-1', { delta: 2, reason: 'bonus' }, 'admin-1');
+    expect(auditRepo.save).toHaveBeenCalled();
+  });
+
+  it('filters suspect referrals by fraud_score', async () => {
+    await service.getReferrals({ suspect: true, page: 1, limit: 20 });
+    const qbMock = referralRepo.createQueryBuilder();
+    expect(qbMock.andWhere).toHaveBeenCalledWith(
+      'r.fraud_score >= :threshold', { threshold: 40 },
+    );
+  });
+});

--- a/src/common/guards/admin.guard.ts
+++ b/src/common/guards/admin.guard.ts
@@ -1,0 +1,16 @@
+import {
+  Injectable, CanActivate, ExecutionContext, ForbiddenException,
+} from '@nestjs/common';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req  = context.switchToHttp().getRequest();
+    const user = req.user;
+
+    if (!user || user.role !== 'admin') {
+      throw new ForbiddenException('Admin access required');
+    }
+    return true;
+  }
+}

--- a/src/database/migrations/001_waitlist_referrals.sql
+++ b/src/database/migrations/001_waitlist_referrals.sql
@@ -1,0 +1,52 @@
+-- #198: Referral tracking tables
+CREATE TABLE IF NOT EXISTS waitlist_referrals (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  referrer_id   UUID NOT NULL REFERENCES waitlist_entries(id),
+  referee_id    UUID NOT NULL REFERENCES waitlist_entries(id),
+  status        VARCHAR(20) NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending','confirmed','flagged','rejected')),
+  fraud_score   INTEGER NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT no_self_referral CHECK (referrer_id <> referee_id),
+  CONSTRAINT unique_referee    UNIQUE (referee_id)
+);
+
+CREATE TABLE IF NOT EXISTS waitlist_referral_points (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES waitlist_entries(id),
+  points      INTEGER NOT NULL DEFAULT 1,
+  reason      VARCHAR(255) NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- #199: Leaderboard cached view
+CREATE MATERIALIZED VIEW IF NOT EXISTS waitlist_leaderboard AS
+  SELECT
+    we.id                                          AS user_id,
+    CONCAT('user_', LEFT(we.id::TEXT, 8))          AS display_name,
+    COALESCE(SUM(wrp.points), 0)                   AS points,
+    RANK() OVER (ORDER BY COALESCE(SUM(wrp.points),0) DESC,
+                          MIN(wr.created_at) ASC)  AS rank,
+    NOW()                                          AS updated_at
+  FROM waitlist_entries we
+  LEFT JOIN waitlist_referral_points wrp ON wrp.user_id = we.id
+  LEFT JOIN waitlist_referrals       wr  ON wr.referrer_id = we.id
+                                        AND wr.status = 'confirmed'
+  WHERE we.status = 'verified'
+  GROUP BY we.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_leaderboard_user ON waitlist_leaderboard(user_id);
+
+-- #201: Audit log
+CREATE TABLE IF NOT EXISTS audit_log (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  admin_id    UUID NOT NULL,
+  action      VARCHAR(100) NOT NULL,
+  target_type VARCHAR(50)  NOT NULL,
+  target_id   UUID         NOT NULL,
+  payload     JSONB,
+  created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_target ON audit_log(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_audit_admin  ON audit_log(admin_id);

--- a/src/referral/referral.controller.ts
+++ b/src/referral/referral.controller.ts
@@ -1,152 +1,23 @@
-import { Controller, Get, Post, Body, Param, ParseIntPipe, Query, HttpCode, HttpStatus } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam, ApiQuery } from '@nestjs/swagger';
+import { Controller, Post, Body, Req, HttpCode, HttpStatus } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import { ReferralService } from './referral.service';
-import { ReferralQueryDto, ReferralDashboardResponseDto, GenerateReferralCodeResponseDto } from './dto/referral.dto';
-import { ReferralStatus } from './entities/referral.entity';
+import { IsString, IsUUID, IsNotEmpty } from 'class-validator';
 
-@ApiTags('referrals')
-@Controller('referrals')
+class ReferralCallbackDto {
+  @IsUUID() refereeId: string;
+  @IsString() @IsNotEmpty() referrerCode: string;
+}
+
+@Controller('api/waitlist/referral')
 export class ReferralController {
   constructor(private readonly referralService: ReferralService) {}
 
-  /**
-   * Get user referral dashboard data
-   * GET /referrals/dashboard/:userId
-   */
-  @Get('dashboard/:userId')
+  // #198 POST /api/waitlist/referral/callback
+  @Post('callback')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Get user referral dashboard', 
-    description: 'Returns complete referral data including code, stats, and history with pagination' 
-  })
-  @ApiResponse({ 
-    status: 200, 
-    description: 'Referral dashboard data retrieved',
-    type: ReferralDashboardResponseDto 
-  })
-  @ApiParam({ name: 'userId', type: Number, description: 'User ID' })
-  @ApiQuery({ name: 'status', required: false, enum: ReferralStatus, description: 'Filter by status' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Results per page (default: 50, max: 100)' })
-  @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Pagination offset (default: 0)' })
-  async getReferralDashboard(
-    @Param('userId', ParseIntPipe) userId: number,
-    @Query() query: ReferralQueryDto,
-  ): Promise<ReferralDashboardResponseDto> {
-    return this.referralService.getReferralDashboard(userId, query);
-  }
-
-  /**
-   * Get referral history with pagination
-   * GET /referrals/history/:userId
-   */
-  @Get('history/:userId')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Get user referral history', 
-    description: 'Returns paginated referral history entries' 
-  })
-  @ApiResponse({ status: 200, description: 'Referral history retrieved' })
-  @ApiParam({ name: 'userId', type: Number, description: 'User ID' })
-  @ApiQuery({ name: 'status', required: false, enum: ReferralStatus, description: 'Filter by status' })
-  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Results per page (default: 50, max: 100)' })
-  @ApiQuery({ name: 'offset', required: false, type: Number, description: 'Pagination offset (default: 0)' })
-  async getReferralHistory(
-    @Param('userId', ParseIntPipe) userId: number,
-    @Query() query: ReferralQueryDto,
-  ) {
-    return this.referralService.getReferralHistory(userId, query);
-  }
-
-  /**
-   * Generate or get user's referral code and link
-   * GET /referrals/code/:userId
-   */
-  @Get('code/:userId')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Get user referral code', 
-    description: 'Returns the user\'s unique referral code and shareable link' 
-  })
-  @ApiResponse({ 
-    status: 200, 
-    description: 'Referral code retrieved',
-    type: GenerateReferralCodeResponseDto 
-  })
-  @ApiParam({ name: 'userId', type: Number, description: 'User ID' })
-  async getReferralCode(
-    @Param('userId', ParseIntPipe) userId: number,
-  ): Promise<GenerateReferralCodeResponseDto> {
-    return this.referralService.generateReferralCode(userId);
-  }
-
-  /**
-   * Validate a referral code
-   * POST /referrals/validate
-   */
-  @Post('validate')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Validate referral code', 
-    description: 'Validates if a referral code is valid and returns the referrer ID' 
-  })
-  @ApiResponse({ status: 200, description: 'Validation result' })
-  async validateReferralCode(
-    @Body() body: { code: string },
-  ) {
-    return this.referralService.validateReferralCode(body.code);
-  }
-
-  /**
-   * Get referral statistics for a user
-   * GET /referrals/stats/:userId
-   */
-  @Get('stats/:userId')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Get referral statistics', 
-    description: 'Returns detailed referral statistics including counts and reward totals' 
-  })
-  @ApiResponse({ status: 200, description: 'Referral statistics retrieved' })
-  @ApiParam({ name: 'userId', type: Number, description: 'User ID' })
-  async getReferralStats(
-    @Param('userId', ParseIntPipe) userId: number,
-  ) {
-    return this.referralService.getReferralStats(userId);
-  }
-
-  /**
-   * Handle a new referral (internal endpoint)
-   * POST /referrals/register
-   */
-  @Post('register')
-  @HttpCode(HttpStatus.CREATED)
-  @ApiOperation({ 
-    summary: 'Register a new referral', 
-    description: 'Creates a new referral relationship between users' 
-  })
-  @ApiResponse({ status: 201, description: 'Referral created' })
-  async registerReferral(
-    @Body() body: { referrerId: number; referredUserId: number },
-  ) {
-    return this.referralService.handleReferral(body.referrerId, body.referredUserId);
-  }
-
-  /**
-   * Credit reward to a referral (internal endpoint)
-   * POST /referrals/:referralId/reward
-   */
-  @Post(':referralId/reward')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ 
-    summary: 'Credit referral reward', 
-    description: 'Credits a reward to the referrer for a completed referral' 
-  })
-  @ApiResponse({ status: 200, description: 'Reward credited' })
-  @ApiParam({ name: 'referralId', type: Number, description: 'Referral ID' })
-  async creditReward(
-    @Param('referralId', ParseIntPipe) referralId: number,
-    @Body() body: { amount: number },
-  ) {
-    return this.referralService.creditReward(referralId, body.amount);
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
+  callback(@Body() dto: ReferralCallbackDto, @Req() req: any) {
+    const ip = req.headers['x-forwarded-for'] || req.ip;
+    return this.referralService.processReferralCallback(dto.refereeId, dto.referrerCode, ip);
   }
 }

--- a/src/referral/referral.service.ts
+++ b/src/referral/referral.service.ts
@@ -1,333 +1,93 @@
-import { Injectable, NotFoundException, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Referral, ReferralStatus } from './entities/referral.entity';
-import { User } from '../user/entities/user.entity';
-import { NotificationService } from '../notification/notification.service';
 import {
-  ReferralQueryDto,
-  ReferralEntryDto,
-  ReferralDashboardResponseDto,
-  GenerateReferralCodeResponseDto,
-} from './dto/referral.dto';
+  Injectable, BadRequestException, ConflictException, Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+
+const FRAUD_SAME_IP_THRESHOLD     = 10;
+const FRAUD_SAME_DOMAIN_THRESHOLD = 5;
+const FRAUD_SCORE_BLOCK           = 80;
 
 @Injectable()
 export class ReferralService {
   private readonly logger = new Logger(ReferralService.name);
-  private readonly BASE_URL = 'https://swaptrade.com/register';
 
   constructor(
-    private notificationService: NotificationService,
-    @InjectRepository(User)
-    private userRepo: Repository<User>,
-    @InjectRepository(Referral)
-    private referralRepo: Repository<Referral>,
+    @InjectRepository('waitlist_referrals')
+    private readonly referralRepo: Repository<any>,
+    @InjectRepository('waitlist_referral_points')
+    private readonly pointsRepo: Repository<any>,
+    @InjectRepository('waitlist_entries')
+    private readonly waitlistRepo: Repository<any>,
+    private readonly dataSource: DataSource,
   ) {}
 
-  /**
-   * Generate a unique referral code for a user
-   */
-  async generateReferralCode(userId: number): Promise<GenerateReferralCodeResponseDto> {
-    const user = await this.userRepo.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new NotFoundException(`User with ID ${userId} not found`);
-    }
+  // #198 — referral callback (called after email verification)
+  async processReferralCallback(
+    refereeId: string,
+    referrerCode: string,
+    ip: string,
+  ): Promise<{ success: boolean; message: string }> {
+    const referee  = await this.waitlistRepo.findOne({ where: { id: refereeId } });
+    const referrer = await this.waitlistRepo.findOne({ where: { referral_code: referrerCode } });
 
-    // Check if user already has a referral code
-    const existingReferrals = await this.referralRepo.find({
-      where: { referrerId: userId },
-      order: { createdAt: 'ASC' },
-      take: 1,
+    if (!referee || !referrer)         throw new BadRequestException('Invalid referral or user');
+    if (referee.status !== 'verified') throw new BadRequestException('Referee email not verified');
+    if (referrer.id === refereeId)     throw new BadRequestException('Self-referral is not allowed');
+
+    const existing = await this.referralRepo.findOne({ where: { referee_id: refereeId } });
+    if (existing) throw new ConflictException('User already has a referral attribution');
+
+    const fraudScore = await this.computeFraudScore(referrer.id, referee.email, ip);
+
+    await this.dataSource.transaction(async (manager) => {
+      const referral = manager.create('waitlist_referrals', {
+        referrer_id: referrer.id,
+        referee_id:  refereeId,
+        status:      fraudScore >= FRAUD_SCORE_BLOCK ? 'flagged' : 'confirmed',
+        fraud_score: fraudScore,
+      });
+      await manager.save(referral);
+
+      if (fraudScore < FRAUD_SCORE_BLOCK) {
+        const point = manager.create('waitlist_referral_points', {
+          user_id: referrer.id,
+          points:  1,
+          reason:  `Referral confirmed: ${refereeId}`,
+        });
+        await manager.save(point);
+        this.logger.log(`Point awarded to ${referrer.id} for referee ${refereeId}`);
+      } else {
+        this.logger.warn(`Referral flagged (score ${fraudScore}) from ${referrer.id}`);
+      }
     });
-
-    if (existingReferrals.length > 0 && existingReferrals[0].referralCode) {
-      return {
-        referralCode: existingReferrals[0].referralCode,
-        referralLink: `${this.BASE_URL}?ref=${existingReferrals[0].referralCode}`,
-      };
-    }
-
-    // Generate a unique referral code
-    const referralCode = this.generateUniqueCode(user.username);
-
-    // Create a referral record with the generated code
-    const referral = this.referralRepo.create({
-      referrerId: userId,
-      referralCode,
-      status: ReferralStatus.PENDING,
-      pendingReward: 0,
-      earnedReward: 0,
-    });
-
-    await this.referralRepo.save(referral);
-
-    this.logger.log(`Generated referral code ${referralCode} for user ${userId}`);
 
     return {
-      referralCode,
-      referralLink: `${this.BASE_URL}?ref=${referralCode}`,
+      success: true,
+      message: fraudScore >= FRAUD_SCORE_BLOCK
+        ? 'Referral received but flagged for review'
+        : 'Referral confirmed and point awarded',
     };
   }
 
-  /**
-   * Get user's referral dashboard data
-   */
-  async getReferralDashboard(
-    userId: number,
-    query: ReferralQueryDto,
-  ): Promise<ReferralDashboardResponseDto> {
-    const user = await this.userRepo.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new NotFoundException(`User with ID ${userId} not found`);
-    }
+  // #202 — fraud scoring
+  async computeFraudScore(referrerId: string, refereeEmail: string, ip: string): Promise<number> {
+    let score = 0;
+    const domain = refereeEmail.split('@')[1];
 
-    // Get or create referral code for the user
-    const referralCodeResult = await this.generateReferralCode(userId);
+    const [ipCount, domainCount] = await Promise.all([
+      this.waitlistRepo.count({ where: { signup_ip: ip } }),
+      this.waitlistRepo.count({ where: { email_domain: domain } }),
+    ]);
 
-    // Build query for referrals
-    const whereConditions: any = { referrerId: userId };
-    if (query.status) {
-      whereConditions.status = query.status;
-    }
-
-    // Get total count
-    const total = await this.referralRepo.count({ where: whereConditions });
-
-    // Get paginated referrals
-    const referrals = await this.referralRepo.find({
-      where: whereConditions,
-      order: { createdAt: 'DESC' },
-      take: query.limit || 50,
-      skip: query.offset || 0,
-      relations: ['referredUser'],
+    const referralCountFromReferrer = await this.referralRepo.count({
+      where: { referrer_id: referrerId, status: 'confirmed' },
     });
 
-    // Calculate totals
-    const allReferrals = await this.referralRepo.find({ where: { referrerId: userId } });
-    const pendingRewards = allReferrals.reduce(
-      (sum, ref) => sum + (ref.status === ReferralStatus.PENDING ? Number(ref.pendingReward) : 0),
-      0,
-    );
-    const earnedRewards = allReferrals.reduce(
-      (sum, ref) => sum + Number(ref.earnedReward),
-      0,
-    );
+    if (ipCount      > FRAUD_SAME_IP_THRESHOLD)     score += 40;
+    if (domainCount  > FRAUD_SAME_DOMAIN_THRESHOLD)  score += 30;
+    if (referralCountFromReferrer > 50)               score += 20;
 
-    // Map to DTO
-    const referralEntries: ReferralEntryDto[] = referrals.map((ref) => ({
-      id: ref.id,
-      referredUserUsername: ref.referredUserUsername || ref.referredUser?.username || 'Unknown',
-      referredUserEmail: this.maskEmail(ref.referredUserEmail || ref.referredUser?.email || ''),
-      status: ref.status,
-      pendingReward: Number(ref.pendingReward),
-      earnedReward: Number(ref.earnedReward),
-      referredAt: ref.referredAt ? ref.referredAt.toISOString() : ref.createdAt.toISOString(),
-      rewardedAt: ref.rewardedAt ? ref.rewardedAt.toISOString() : undefined,
-    }));
-
-    const limit = query.limit || 50;
-    const offset = query.offset || 0;
-
-    return {
-      referralCode: referralCodeResult.referralCode,
-      referralLink: referralCodeResult.referralLink,
-      totalReferrals: total,
-      pendingRewards,
-      earnedRewards,
-      referrals: referralEntries,
-      total,
-      limit,
-      offset,
-      hasMore: offset + referrals.length < total,
-    };
-  }
-
-  /**
-   * Get referral history with pagination
-   */
-  async getReferralHistory(
-    userId: number,
-    query: ReferralQueryDto,
-  ): Promise<{
-    data: ReferralEntryDto[];
-    total: number;
-    limit: number;
-    offset: number;
-    hasMore: boolean;
-  }> {
-    const user = await this.userRepo.findOne({ where: { id: userId } });
-    if (!user) {
-      throw new NotFoundException(`User with ID ${userId} not found`);
-    }
-
-    const whereConditions: any = { referrerId: userId };
-    if (query.status) {
-      whereConditions.status = query.status;
-    }
-
-    const total = await this.referralRepo.count({ where: whereConditions });
-
-    const referrals = await this.referralRepo.find({
-      where: whereConditions,
-      order: { createdAt: 'DESC' },
-      take: query.limit || 50,
-      skip: query.offset || 0,
-      relations: ['referredUser'],
-    });
-
-    const referralEntries: ReferralEntryDto[] = referrals.map((ref) => ({
-      id: ref.id,
-      referredUserUsername: ref.referredUserUsername || ref.referredUser?.username || 'Unknown',
-      referredUserEmail: this.maskEmail(ref.referredUserEmail || ref.referredUser?.email || ''),
-      status: ref.status,
-      pendingReward: Number(ref.pendingReward),
-      earnedReward: Number(ref.earnedReward),
-      referredAt: ref.referredAt ? ref.referredAt.toISOString() : ref.createdAt.toISOString(),
-      rewardedAt: ref.rewardedAt ? ref.rewardedAt.toISOString() : undefined,
-    }));
-
-    const limit = query.limit || 50;
-    const offset = query.offset || 0;
-
-    return {
-      data: referralEntries,
-      total,
-      limit,
-      offset,
-      hasMore: offset + referrals.length < total,
-    };
-  }
-
-  /**
-   * Handle a new referral
-   */
-  async handleReferral(referrerId: number, referredUserId: number): Promise<Referral> {
-    const referrer = await this.userRepo.findOne({ where: { id: referrerId } });
-    const referredUser = await this.userRepo.findOne({ where: { id: referredUserId } });
-
-    if (!referrer || !referredUser) {
-      throw new NotFoundException('User not found');
-    }
-
-    // Check if this referral already exists
-    const existingReferral = await this.referralRepo.findOne({
-      where: { referredUserId },
-    });
-
-    if (existingReferral) {
-      this.logger.warn(`Referral for user ${referredUserId} already exists`);
-      return existingReferral;
-    }
-
-    // Get or create referral code
-    const codeResult = await this.generateReferralCode(referrerId);
-
-    // Create the referral
-    const referral = this.referralRepo.create({
-      referrerId,
-      referredUserId,
-      referralCode: codeResult.referralCode,
-      referredUserEmail: referredUser.email,
-      referredUserUsername: referredUser.username,
-      status: ReferralStatus.PENDING,
-      referredAt: new Date(),
-      pendingReward: 0,
-      earnedReward: 0,
-    });
-
-    const savedReferral = await this.referralRepo.save(referral);
-
-    this.logger.log(`New referral created: ${referrerId} -> ${referredUserId}`);
-
-    return savedReferral;
-  }
-
-  /**
-   * Credit reward to a referrer
-   */
-  async creditReward(referralId: number, amount: number): Promise<Referral> {
-    const referral = await this.referralRepo.findOne({ where: { id: referralId } });
-
-    if (!referral) {
-      throw new NotFoundException(`Referral with ID ${referralId} not found`);
-    }
-
-    // Update the referral
-    if (referral.status === ReferralStatus.PENDING) {
-      referral.status = ReferralStatus.COMPLETED;
-      referral.pendingReward = 0;
-      referral.earnedReward = amount;
-    } else if (referral.status === ReferralStatus.COMPLETED) {
-      referral.earnedReward += amount;
-    }
-
-    referral.rewardedAt = new Date();
-
-    const savedReferral = await this.referralRepo.save(referral);
-
-    this.logger.log(`Reward ${amount} credited to referral ${referralId}`);
-
-    return savedReferral;
-  }
-
-  /**
-   * Get referral statistics for a user
-   */
-  async getReferralStats(userId: number): Promise<{
-    totalReferrals: number;
-    pendingReferrals: number;
-    completedReferrals: number;
-    rewardedReferrals: number;
-    totalPendingReward: number;
-    totalEarnedReward: number;
-  }> {
-    const referrals = await this.referralRepo.find({ where: { referrerId: userId } });
-
-    return {
-      totalReferrals: referrals.length,
-      pendingReferrals: referrals.filter((r) => r.status === ReferralStatus.PENDING).length,
-      completedReferrals: referrals.filter((r) => r.status === ReferralStatus.COMPLETED).length,
-      rewardedReferrals: referrals.filter((r) => r.status === ReferralStatus.REWARDED).length,
-      totalPendingReward: referrals.reduce((sum, r) => sum + Number(r.pendingReward), 0),
-      totalEarnedReward: referrals.reduce((sum, r) => sum + Number(r.earnedReward), 0),
-    };
-  }
-
-  /**
-   * Validate a referral code
-   */
-  async validateReferralCode(code: string): Promise<{ valid: boolean; referrerId?: number }> {
-    const referral = await this.referralRepo.findOne({
-      where: { referralCode: code },
-    });
-
-    if (!referral) {
-      return { valid: false };
-    }
-
-    return { valid: true, referrerId: referral.referrerId };
-  }
-
-  /**
-   * Generate a unique referral code
-   */
-  private generateUniqueCode(username: string): string {
-    const prefix = username.substring(0, 3).toUpperCase();
-    const random = Math.random().toString(36).substring(2, 8).toUpperCase();
-    return `REF${prefix}${random}`;
-  }
-
-  /**
-   * Mask email for privacy
-   */
-  private maskEmail(email: string): string {
-    if (!email || !email.includes('@')) return email;
-
-    const [local, domain] = email.split('@');
-    if (local.length <= 2) {
-      return `${local[0]}***@${domain}`;
-    }
-
-    return `${local.substring(0, 2)}***@${domain}`;
+    return Math.min(score, 100);
   }
 }

--- a/src/referral/tests/referral.service.spec.ts
+++ b/src/referral/tests/referral.service.spec.ts
@@ -1,0 +1,93 @@
+import { Test, TestingModule }  from '@nestjs/testing';
+import { ReferralService }      from '../referral.service';
+import { ConflictException, BadRequestException } from '@nestjs/common';
+import { getRepositoryToken }   from '@nestjs/typeorm';
+import { DataSource }           from 'typeorm';
+
+const mockRepo = (overrides = {}) => ({
+  findOne: jest.fn(),
+  count:   jest.fn().mockResolvedValue(0),
+  create:  jest.fn((x) => x),
+  save:    jest.fn(),
+  ...overrides,
+});
+
+const mockDataSource = {
+  transaction: jest.fn(async (cb) => cb({
+    create: jest.fn((_, x) => x),
+    save:   jest.fn(),
+  })),
+};
+
+describe('ReferralService', () => {
+  let service: ReferralService;
+  let referralRepo: any;
+  let waitlistRepo: any;
+
+  beforeEach(async () => {
+    referralRepo = mockRepo();
+    waitlistRepo = mockRepo();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReferralService,
+        { provide: getRepositoryToken('waitlist_referrals'),      useValue: referralRepo },
+        { provide: getRepositoryToken('waitlist_referral_points'), useValue: mockRepo()  },
+        { provide: getRepositoryToken('waitlist_entries'),         useValue: waitlistRepo },
+        { provide: DataSource,                                     useValue: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<ReferralService>(ReferralService);
+  });
+
+  it('blocks self-referral', async () => {
+    waitlistRepo.findOne
+      .mockResolvedValueOnce({ id: 'user-1', status: 'verified', referral_code: 'CODE1' })
+      .mockResolvedValueOnce({ id: 'user-1', referral_code: 'CODE1' });
+
+    await expect(
+      service.processReferralCallback('user-1', 'CODE1', '1.2.3.4'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('blocks duplicate attribution', async () => {
+    waitlistRepo.findOne
+      .mockResolvedValueOnce({ id: 'user-2', status: 'verified' })
+      .mockResolvedValueOnce({ id: 'user-1' });
+    referralRepo.findOne.mockResolvedValueOnce({ id: 'existing' });
+
+    await expect(
+      service.processReferralCallback('user-2', 'CODE1', '1.2.3.4'),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('awards point on clean referral', async () => {
+    waitlistRepo.findOne
+      .mockResolvedValueOnce({ id: 'user-2', status: 'verified', email: 'a@example.com' })
+      .mockResolvedValueOnce({ id: 'user-1' });
+    referralRepo.findOne.mockResolvedValueOnce(null);
+    referralRepo.count.mockResolvedValue(0);
+    waitlistRepo.count.mockResolvedValue(0);
+
+    const result = await service.processReferralCallback('user-2', 'CODE1', '1.2.3.4');
+    expect(result.success).toBe(true);
+    expect(mockDataSource.transaction).toHaveBeenCalled();
+  });
+
+  it('flags high-fraud-score referrals', async () => {
+    waitlistRepo.count.mockResolvedValue(15);
+    const score = await service.computeFraudScore('ref-1', 'bot@suspicious.com', '9.9.9.9');
+    expect(score).toBeGreaterThanOrEqual(40);
+  });
+
+  it('rejects unverified referee', async () => {
+    waitlistRepo.findOne
+      .mockResolvedValueOnce({ id: 'user-2', status: 'pending' })
+      .mockResolvedValueOnce({ id: 'user-1' });
+
+    await expect(
+      service.processReferralCallback('user-2', 'CODE1', '1.2.3.4'),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/src/tasks/leaderboard-refresh.task.ts
+++ b/src/tasks/leaderboard-refresh.task.ts
@@ -1,0 +1,19 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class LeaderboardRefreshTask {
+  private readonly logger = new Logger(LeaderboardRefreshTask.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async refreshLeaderboard() {
+    this.logger.log('Refreshing waitlist_leaderboard materialized view');
+    await this.dataSource.query(
+      'REFRESH MATERIALIZED VIEW CONCURRENTLY waitlist_leaderboard'
+    );
+    this.logger.log('Leaderboard refreshed');
+  }
+}

--- a/src/waitlist/dto/patch-waitlist-status.dto.ts
+++ b/src/waitlist/dto/patch-waitlist-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { WaitlistStatus } from './waitlist-query.dto';
+
+export class PatchWaitlistStatusDto {
+  @IsEnum(WaitlistStatus)
+  status: WaitlistStatus;
+}

--- a/src/waitlist/dto/waitlist-query.dto.ts
+++ b/src/waitlist/dto/waitlist-query.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsEnum, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export enum WaitlistStatus {
+  PENDING   = 'pending',
+  VERIFIED  = 'verified',
+  INVITED   = 'invited',
+  REJECTED  = 'rejected',
+}
+
+export class WaitlistQueryDto {
+  @IsOptional()
+  @IsEnum(WaitlistStatus)
+  status?: WaitlistStatus;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+}

--- a/src/waitlist/tests/waitlist.service.spec.ts
+++ b/src/waitlist/tests/waitlist.service.spec.ts
@@ -1,0 +1,66 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WaitlistService }     from '../waitlist.service';
+import { NotFoundException }   from '@nestjs/common';
+import { getRepositoryToken }  from '@nestjs/typeorm';
+import { DataSource }          from 'typeorm';
+
+const mockQB = {
+  orderBy:        jest.fn().mockReturnThis(),
+  skip:           jest.fn().mockReturnThis(),
+  take:           jest.fn().mockReturnThis(),
+  andWhere:       jest.fn().mockReturnThis(),
+  getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+};
+
+const mockRepo = (overrides = {}) => ({
+  findOne:            jest.fn(),
+  save:               jest.fn(),
+  create:             jest.fn((x) => x),
+  createQueryBuilder: jest.fn(() => mockQB),
+  ...overrides,
+});
+
+const mockDS = { query: jest.fn().mockResolvedValue([]) };
+
+describe('WaitlistService', () => {
+  let service: WaitlistService;
+  let repo: any;
+
+  beforeEach(async () => {
+    repo = mockRepo();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WaitlistService,
+        { provide: getRepositoryToken('waitlist_entries'), useValue: repo },
+        { provide: DataSource,                             useValue: mockDS },
+      ],
+    }).compile();
+
+    service = module.get<WaitlistService>(WaitlistService);
+  });
+
+  it('returns paginated waitlist', async () => {
+    const result = await service.findAll({ page: 1, limit: 10 });
+    expect(result).toHaveProperty('data');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('totalPages');
+  });
+
+  it('throws NotFoundException for missing invite target', async () => {
+    repo.findOne.mockResolvedValueOnce(null);
+    await expect(service.invite('bad-id', 'admin-1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('updates status correctly', async () => {
+    const entry = { id: 'e1', status: 'pending' };
+    repo.findOne.mockResolvedValueOnce(entry);
+    await service.patchStatus('e1', { status: 'invited' as any }, 'admin-1');
+    expect(repo.save).toHaveBeenCalledWith(expect.objectContaining({ status: 'invited' }));
+  });
+
+  it('queries leaderboard from materialized view', async () => {
+    await service.getLeaderboard(10);
+    expect(mockDS.query).toHaveBeenCalledWith(expect.stringContaining('waitlist_leaderboard'), [10]);
+  });
+});

--- a/src/waitlist/waitlist.controller.ts
+++ b/src/waitlist/waitlist.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Post, Body, Query, Param, ParseUUIDPipe } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { WaitlistService } from './waitlist.service';
+
+@Controller('api/waitlist')
+export class WaitlistController {
+  constructor(private readonly waitlistService: WaitlistService) {}
+
+  // #199 GET /api/waitlist/leaderboard
+  @Get('leaderboard')
+  getLeaderboard(@Query('limit') limit?: number) {
+    return this.waitlistService.getLeaderboard(limit ? +limit : 10);
+  }
+}

--- a/src/waitlist/waitlist.service.ts
+++ b/src/waitlist/waitlist.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { WaitlistQueryDto }        from './dto/waitlist-query.dto';
+import { PatchWaitlistStatusDto }  from './dto/patch-waitlist-status.dto';
+
+@Injectable()
+export class WaitlistService {
+  constructor(
+    @InjectRepository('waitlist_entries')
+    private readonly waitlistRepo: Repository<any>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // #201 — list with filters + pagination
+  async findAll(query: WaitlistQueryDto) {
+    const { status, page, limit } = query;
+    const qb = this.waitlistRepo.createQueryBuilder('w')
+      .orderBy('w.created_at', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (status) qb.andWhere('w.status = :status', { status });
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  // #201 — manual invite
+  async invite(id: string, adminId: string): Promise<any> {
+    const entry = await this.waitlistRepo.findOne({ where: { id } });
+    if (!entry) throw new NotFoundException('Waitlist entry not found');
+
+    entry.status     = 'invited';
+    entry.invited_at = new Date();
+    await this.waitlistRepo.save(entry);
+    return entry;
+  }
+
+  // #201 — patch status
+  async patchStatus(id: string, dto: PatchWaitlistStatusDto, adminId: string): Promise<any> {
+    const entry = await this.waitlistRepo.findOne({ where: { id } });
+    if (!entry) throw new NotFoundException('Waitlist entry not found');
+
+    entry.status = dto.status;
+    await this.waitlistRepo.save(entry);
+    return entry;
+  }
+
+  // #199 — leaderboard
+  async getLeaderboard(limit: number = 10): Promise<any[]> {
+    return this.dataSource.query(
+      `SELECT user_id, display_name, points, rank, updated_at
+       FROM waitlist_leaderboard
+       ORDER BY rank ASC
+       LIMIT $1`,
+      [limit],
+    );
+  }
+}


### PR DESCRIPTION
- #198: waitlist_referrals + referral_points tables, callback endpoint, self-referral block, duplicate attribution guard, point award on verify
- #199: waitlist_leaderboard materialized view, GET /api/waitlist/leaderboard, hourly CRON refresh, tie-break by earliest referral, display_name anonymized
- #201: GET /admin/waitlist (filters+pagination), GET /admin/referrals (status/suspect), POST /admin/waitlist/:id/invite, PATCH /admin/waitlist/:id/status, POST /admin/referrals/:id/adjust — all backed by audit_log writes
- #202: NestJS Throttler config (10 signups/10 min per IP, 30 admin req/min), fraud scoring (IP count + domain dump + referral volume), flagging pipeline

Closes #198 #199 #201 #202