### PR TITLE
feat: KYC storage limits, input validation, replay attack prevention, and deterministic rate limiting

### DIFF
--- a/src/common/guards/replay-attack.guard.ts
+++ b/src/common/guards/replay-attack.guard.ts
@@ -1,0 +1,54 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+
+const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_CACHE_SIZE = 10_000;
+
+@Injectable()
+export class ReplayAttackGuard implements CanActivate {
+  private readonly seen = new Map<string, number>();
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    const nonce = req.headers['x-request-nonce'] as string | undefined;
+    const timestampHeader = req.headers['x-request-timestamp'] as string | undefined;
+
+    if (!nonce || !timestampHeader) {
+      throw new UnauthorizedException('Missing replay-protection headers (x-request-nonce, x-request-timestamp).');
+    }
+
+    const timestamp = Number(timestampHeader);
+    if (isNaN(timestamp)) {
+      throw new UnauthorizedException('x-request-timestamp must be a Unix epoch in milliseconds.');
+    }
+
+    const now = Date.now();
+    if (Math.abs(now - timestamp) > NONCE_TTL_MS) {
+      throw new UnauthorizedException('Request timestamp is outside the acceptable window.');
+    }
+
+    if (this.seen.has(nonce)) {
+      throw new UnauthorizedException('Duplicate nonce detected — possible replay attack.');
+    }
+
+    // Evict stale entries before inserting to cap memory usage
+    this.evictExpired(now);
+    this.seen.set(nonce, timestamp);
+
+    return true;
+  }
+
+  private evictExpired(now: number): void {
+    if (this.seen.size < MAX_CACHE_SIZE) return;
+    for (const [key, ts] of this.seen.entries()) {
+      if (now - ts > NONCE_TTL_MS) {
+        this.seen.delete(key);
+      }
+    }
+  }
+}

--- a/src/kyc/dto/validate-kyc-submission.dto.ts
+++ b/src/kyc/dto/validate-kyc-submission.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsEmail,
+  IsDateString,
+  Length,
+  Matches,
+  IsEnum,
+} from 'class-validator';
+
+export enum DocumentType {
+  PASSPORT = 'passport',
+  NATIONAL_ID = 'national_id',
+  DRIVERS_LICENSE = 'drivers_license',
+}
+
+export class ValidateKycSubmissionDto {
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 100)
+  fullName: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsDateString()
+  dateOfBirth: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(2, 100)
+  country: string;
+
+  @IsEnum(DocumentType)
+  documentType: DocumentType;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(4, 30)
+  @Matches(/^[A-Z0-9-]+$/i, {
+    message: 'documentNumber must contain only alphanumeric characters and hyphens',
+  })
+  documentNumber: string;
+}

--- a/src/kyc/kyc-storage-limit.service.ts
+++ b/src/kyc/kyc-storage-limit.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+
+const MAX_DOCUMENT_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const MAX_DOCUMENTS_PER_USER = 10;
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf'];
+
+export interface KycDocumentMeta {
+  mimeType: string;
+  sizeBytes: number;
+}
+
+@Injectable()
+export class KycStorageLimitService {
+  validateDocument(doc: KycDocumentMeta): void {
+    if (!ALLOWED_MIME_TYPES.includes(doc.mimeType)) {
+      throw new BadRequestException(
+        `Unsupported file type "${doc.mimeType}". Allowed: ${ALLOWED_MIME_TYPES.join(', ')}.`,
+      );
+    }
+
+    if (doc.sizeBytes > MAX_DOCUMENT_SIZE_BYTES) {
+      throw new BadRequestException(
+        `File size ${doc.sizeBytes} bytes exceeds the ${MAX_DOCUMENT_SIZE_BYTES / (1024 * 1024)} MB limit.`,
+      );
+    }
+  }
+
+  assertDocumentQuota(existingCount: number): void {
+    if (existingCount >= MAX_DOCUMENTS_PER_USER) {
+      throw new BadRequestException(
+        `KYC document quota reached (max ${MAX_DOCUMENTS_PER_USER} per user). Remove an existing document before uploading a new one.`,
+      );
+    }
+  }
+}

--- a/src/ratelimit/deterministic-rate-limit.service.ts
+++ b/src/ratelimit/deterministic-rate-limit.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+
+interface BucketState {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+/**
+ * Token-bucket rate limiter with deterministic refill.
+ * Each (key, endpoint) pair gets its own bucket so limits are
+ * enforced independently per sensitive API route.
+ */
+@Injectable()
+export class DeterministicRateLimitService {
+  private readonly buckets = new Map<string, BucketState>();
+
+  /**
+   * Returns true if the request is allowed, false if rate-limited.
+   *
+   * @param key       Unique caller identifier (e.g. userId or IP)
+   * @param endpoint  Route identifier (e.g. 'kyc-submit')
+   * @param capacity  Max tokens per window
+   * @param refillRatePerMs Tokens added per millisecond
+   */
+  isAllowed(
+    key: string,
+    endpoint: string,
+    capacity: number,
+    refillRatePerMs: number,
+  ): boolean {
+    const bucketKey = `${endpoint}::${key}`;
+    const now = Date.now();
+
+    let bucket = this.buckets.get(bucketKey);
+    if (!bucket) {
+      bucket = { tokens: capacity, lastRefillMs: now };
+      this.buckets.set(bucketKey, bucket);
+    }
+
+    // Deterministic refill based on elapsed time
+    const elapsed = now - bucket.lastRefillMs;
+    bucket.tokens = Math.min(capacity, bucket.tokens + elapsed * refillRatePerMs);
+    bucket.lastRefillMs = now;
+
+    if (bucket.tokens < 1) {
+      return false;
+    }
+
+    bucket.tokens -= 1;
+    return true;
+  }
+
+  /** Remove all buckets for a given key (e.g. on logout). */
+  clearKey(key: string): void {
+    for (const bucketKey of this.buckets.keys()) {
+      if (bucketKey.includes(`::${key}`)) {
+        this.buckets.delete(bucketKey);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **KYC Storage Limits** (`src/kyc/kyc-storage-limit.service.ts`): enforces max file size (5 MB), allowed MIME types, and a per-user document quota (10 documents) before any upload is accepted.
- **KYC Input Validation** (`src/kyc/dto/validate-kyc-submission.dto.ts`): `class-validator` DTO covering fullName, email, dateOfBirth, country, documentType enum, and alphanumeric documentNumber.
- **Replay Attack Guard** (`src/common/guards/replay-attack.guard.ts`): NestJS guard that validates `x-request-nonce` and `x-request-timestamp` headers, rejects duplicate nonces and stale timestamps (5-minute window).
- **Deterministic Rate Limiter** (`src/ratelimit/deterministic-rate-limit.service.ts`): token-bucket service with per-(key, endpoint) buckets and time-based deterministic refill for sensitive API routes.

closes #346
closes #347
closes #348
closes #349