### PR TITLE
feat: Implement Trading Bonuses System

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -57,6 +57,8 @@ import { MarketSurveillanceModule } from './market-surveillance/market-surveilla
 import { DatabaseModule } from './database/database.module';
 import { HorizontalScalingModule } from './queue/horizontal-scaling.module';
 import { MLPipelineModule } from './ml-pipeline/ml-pipeline.module';
+import { TradingBonusesModule } from './trading-bonuses/trading-bonuses.module';
+import { TradingBonus } from './trading-bonuses/entities/trading-bonus.entity';
 
 import { 
   AnomalyAlert, 
@@ -113,7 +115,7 @@ import * as path from 'path';
         PortfolioSnapshot, RiskMetrics, PerformanceHistory, Benchmark,
         AnomalyAlert, OrderBookSnapshot, SuspiciousActor, ViolationEvent, HeatmapMetric, PatternTemplate,
         TrainingJob, ModelVersion, PerformanceMetrics,
-        UserBalance, VirtualAsset, KycRecord,
+        UserBalance, VirtualAsset, KycRecord, TradingBonus,
       ],
       synchronize: true,
     }),
@@ -129,6 +131,7 @@ import * as path from 'path';
     PricePredictionModule,
     PrivacyModule,
     KycModule,
+    TradingBonusesModule,
     ErrorModule,
     DatabaseModule,
     // Note: Some modules are now loaded dynamically to optimize startup

--- a/src/trading-bonuses/dto/trading-bonus.dto.ts
+++ b/src/trading-bonuses/dto/trading-bonus.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsOptional, IsInt, Min, Matches } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class BonusQueryDto {
+  @IsOptional()
+  @IsString()
+  month?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+}
+
+export class CalculateBonusDto {
+  @IsInt()
+  @Min(1)
+  userId: number;
+
+  @IsString()
+  @Matches(/^\d{4}-\d{2}$/, { message: 'month must be in YYYY-MM format' })
+  month: string;
+}

--- a/src/trading-bonuses/entities/trading-bonus.entity.ts
+++ b/src/trading-bonuses/entities/trading-bonus.entity.ts
@@ -1,0 +1,73 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum BonusStatus {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+  CANCELLED = 'CANCELLED',
+}
+
+/**
+ * Trading volume tiers and their corresponding bonus percentages.
+ * < $1 000        → 0 %
+ * $1 000–$9 999   → 1 %
+ * $10 000–$99 999 → 2 %
+ * ≥ $100 000      → 3 %
+ */
+export const BONUS_TIERS = [
+  { minVolume: 100_000, rate: 0.03 },
+  { minVolume: 10_000, rate: 0.02 },
+  { minVolume: 1_000, rate: 0.01 },
+  { minVolume: 0, rate: 0 },
+] as const;
+
+@Entity('trading_bonuses')
+@Index(['userId', 'month'], { unique: true })
+@Index(['status'])
+@Index(['month'])
+export class TradingBonus {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id' })
+  @Index()
+  userId: number;
+
+  /** Format: YYYY-MM */
+  @Column({ length: 7 })
+  month: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, name: 'trading_volume', default: '0' })
+  tradingVolume: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8, name: 'bonus_amount', default: '0' })
+  bonusAmount: number;
+
+  @Column({ type: 'decimal', precision: 5, scale: 4, name: 'bonus_rate', default: '0' })
+  bonusRate: number;
+
+  @Column({
+    type: 'enum',
+    enum: BonusStatus,
+    default: BonusStatus.PENDING,
+  })
+  status: BonusStatus;
+
+  @Column({ name: 'calculated_at', nullable: true })
+  calculatedAt: Date;
+
+  @Column({ name: 'paid_at', nullable: true })
+  paidAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/trading-bonuses/trading-bonuses.controller.ts
+++ b/src/trading-bonuses/trading-bonuses.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  ParseIntPipe,
+  HttpCode,
+  HttpStatus,
+  Body,
+} from '@nestjs/common';
+import { TradingBonusesService } from './trading-bonuses.service';
+import { BonusQueryDto, CalculateBonusDto } from './dto/trading-bonus.dto';
+
+@Controller('trading-bonuses')
+export class TradingBonusesController {
+  constructor(private readonly tradingBonusesService: TradingBonusesService) {}
+
+  /**
+   * Calculate/recalculate the monthly bonus for a specific user.
+   * POST /trading-bonuses/calculate
+   */
+  @Post('calculate')
+  @HttpCode(HttpStatus.OK)
+  async calculateBonus(@Body() dto: CalculateBonusDto) {
+    return this.tradingBonusesService.calculateMonthlyBonus(dto.userId, dto.month);
+  }
+
+  /**
+   * Process all pending payouts for a month (monthly cron trigger).
+   * POST /trading-bonuses/payouts/:month
+   */
+  @Post('payouts/:month')
+  @HttpCode(HttpStatus.OK)
+  async processPayouts(@Param('month') month: string) {
+    return this.tradingBonusesService.processMonthlyPayouts(month);
+  }
+
+  /**
+   * Get bonus history for a specific user.
+   * GET /trading-bonuses/user/:userId
+   */
+  @Get('user/:userId')
+  async getUserBonusHistory(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Query() query: BonusQueryDto,
+  ) {
+    return this.tradingBonusesService.getUserBonusHistory(userId, query);
+  }
+
+  /**
+   * Admin: get summary stats for a month.
+   * GET /trading-bonuses/summary/:month
+   */
+  @Get('summary/:month')
+  async getBonusSummary(@Param('month') month: string) {
+    return this.tradingBonusesService.getBonusSummary(month);
+  }
+}

--- a/src/trading-bonuses/trading-bonuses.module.ts
+++ b/src/trading-bonuses/trading-bonuses.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TradingBonus } from './entities/trading-bonus.entity';
+import { Trade } from '../trading/entities/trade.entity';
+import { TradingBonusesService } from './trading-bonuses.service';
+import { TradingBonusesController } from './trading-bonuses.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TradingBonus, Trade])],
+  providers: [TradingBonusesService],
+  controllers: [TradingBonusesController],
+  exports: [TradingBonusesService],
+})
+export class TradingBonusesModule {}

--- a/src/trading-bonuses/trading-bonuses.service.spec.ts
+++ b/src/trading-bonuses/trading-bonuses.service.spec.ts
@@ -1,0 +1,62 @@
+import { TradingBonusesService } from './trading-bonuses.service';
+
+describe('TradingBonusesService.computeBonus', () => {
+  let service: TradingBonusesService;
+
+  beforeEach(() => {
+    // Instantiate with null repos — only testing pure computeBonus
+    service = new TradingBonusesService(null as any, null as any);
+  });
+
+  it('should return 0% bonus for volume below $1,000', () => {
+    expect(service.computeBonus(0)).toEqual({ bonusRate: 0, bonusAmount: 0 });
+    expect(service.computeBonus(500)).toEqual({ bonusRate: 0, bonusAmount: 0 });
+    expect(service.computeBonus(999.99)).toEqual({ bonusRate: 0, bonusAmount: 0 });
+  });
+
+  it('should return 1% bonus for volume between $1,000 and $9,999.99', () => {
+    const result = service.computeBonus(1000);
+    expect(result.bonusRate).toBe(0.01);
+    expect(result.bonusAmount).toBeCloseTo(10, 5);
+  });
+
+  it('should return 1% bonus for volume of $5,000', () => {
+    const result = service.computeBonus(5000);
+    expect(result.bonusRate).toBe(0.01);
+    expect(result.bonusAmount).toBeCloseTo(50, 5);
+  });
+
+  it('should return 2% bonus for volume between $10,000 and $99,999.99', () => {
+    const result = service.computeBonus(10_000);
+    expect(result.bonusRate).toBe(0.02);
+    expect(result.bonusAmount).toBeCloseTo(200, 5);
+  });
+
+  it('should return 2% bonus for volume of $50,000', () => {
+    const result = service.computeBonus(50_000);
+    expect(result.bonusRate).toBe(0.02);
+    expect(result.bonusAmount).toBeCloseTo(1000, 5);
+  });
+
+  it('should return 3% bonus for volume >= $100,000', () => {
+    const result = service.computeBonus(100_000);
+    expect(result.bonusRate).toBe(0.03);
+    expect(result.bonusAmount).toBeCloseTo(3000, 5);
+  });
+
+  it('should return 3% bonus for volume of $500,000', () => {
+    const result = service.computeBonus(500_000);
+    expect(result.bonusRate).toBe(0.03);
+    expect(result.bonusAmount).toBeCloseTo(15000, 5);
+  });
+
+  it('should return exactly $9,999 → 1% tier', () => {
+    const result = service.computeBonus(9999);
+    expect(result.bonusRate).toBe(0.01);
+  });
+
+  it('should handle exactly $99,999 → 2% tier', () => {
+    const result = service.computeBonus(99_999);
+    expect(result.bonusRate).toBe(0.02);
+  });
+});

--- a/src/trading-bonuses/trading-bonuses.service.ts
+++ b/src/trading-bonuses/trading-bonuses.service.ts
@@ -1,0 +1,154 @@
+import { Injectable, Logger, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { TradingBonus, BonusStatus, BONUS_TIERS } from './entities/trading-bonus.entity';
+import { Trade, TradeStatus } from '../trading/entities/trade.entity';
+import { BonusQueryDto } from './dto/trading-bonus.dto';
+
+@Injectable()
+export class TradingBonusesService {
+  private readonly logger = new Logger(TradingBonusesService.name);
+
+  constructor(
+    @InjectRepository(TradingBonus)
+    private readonly bonusRepo: Repository<TradingBonus>,
+    @InjectRepository(Trade)
+    private readonly tradeRepo: Repository<Trade>,
+  ) {}
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tier calculation (pure, testable)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Computes the bonus rate and amount for a given trading volume.
+   * Tiers: <$1k → 0%, $1k–$10k → 1%, $10k–$100k → 2%, ≥$100k → 3%
+   */
+  computeBonus(tradingVolume: number): { bonusRate: number; bonusAmount: number } {
+    for (const tier of BONUS_TIERS) {
+      if (tradingVolume >= tier.minVolume) {
+        return {
+          bonusRate: tier.rate,
+          bonusAmount: parseFloat((tradingVolume * tier.rate).toFixed(8)),
+        };
+      }
+    }
+    return { bonusRate: 0, bonusAmount: 0 };
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Core operations
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Calculate and upsert the monthly trading bonus for a user.
+   * Sums all EXECUTED trades for the user in the given month.
+   */
+  async calculateMonthlyBonus(userId: number, month: string): Promise<TradingBonus> {
+    const [year, mon] = month.split('-').map(Number);
+    const startDate = new Date(year, mon - 1, 1);
+    const endDate = new Date(year, mon, 1);
+
+    const trades = await this.tradeRepo.find({
+      where: {
+        userId,
+        status: TradeStatus.EXECUTED,
+        createdAt: Between(startDate, endDate),
+      },
+    });
+
+    const tradingVolume = trades.reduce((sum, t) => sum + Number(t.totalValue), 0);
+    const { bonusRate, bonusAmount } = this.computeBonus(tradingVolume);
+
+    const existing = await this.bonusRepo.findOne({ where: { userId, month } });
+
+    if (existing) {
+      existing.tradingVolume = tradingVolume;
+      existing.bonusAmount = bonusAmount;
+      existing.bonusRate = bonusRate;
+      existing.calculatedAt = new Date();
+      return this.bonusRepo.save(existing);
+    }
+
+    const bonus = this.bonusRepo.create({
+      userId,
+      month,
+      tradingVolume,
+      bonusAmount,
+      bonusRate,
+      status: BonusStatus.PENDING,
+      calculatedAt: new Date(),
+    });
+
+    return this.bonusRepo.save(bonus);
+  }
+
+  /**
+   * Process all pending bonuses for a given month (automated monthly payout).
+   */
+  async processMonthlyPayouts(month: string): Promise<{ processed: number; totalPaid: number }> {
+    const pending = await this.bonusRepo.find({
+      where: { month, status: BonusStatus.PENDING },
+    });
+
+    let totalPaid = 0;
+    let processed = 0;
+
+    for (const bonus of pending) {
+      if (bonus.bonusAmount > 0) {
+        bonus.status = BonusStatus.PAID;
+        bonus.paidAt = new Date();
+        await this.bonusRepo.save(bonus);
+        totalPaid += Number(bonus.bonusAmount);
+        processed++;
+        this.logger.log(`Bonus paid: userId=${bonus.userId} month=${month} amount=${bonus.bonusAmount}`);
+      } else {
+        // Zero-amount bonuses are cancelled (below minimum trading volume)
+        bonus.status = BonusStatus.CANCELLED;
+        await this.bonusRepo.save(bonus);
+      }
+    }
+
+    this.logger.log(`Monthly payouts complete: month=${month} processed=${processed} total=$${totalPaid.toFixed(2)}`);
+    return { processed, totalPaid };
+  }
+
+  /**
+   * Get paginated bonus history for a user.
+   */
+  async getUserBonusHistory(userId: number, query: BonusQueryDto) {
+    const { page = 1, limit = 20, month } = query;
+    const qb = this.bonusRepo
+      .createQueryBuilder('b')
+      .where('b.userId = :userId', { userId })
+      .orderBy('b.month', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (month) qb.andWhere('b.month = :month', { month });
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  /**
+   * Admin: summary stats for a given month.
+   */
+  async getBonusSummary(month: string) {
+    const bonuses = await this.bonusRepo.find({ where: { month } });
+
+    const summary = {
+      month,
+      totalBonuses: bonuses.length,
+      totalBonusAmount: bonuses.reduce((s, b) => s + Number(b.bonusAmount), 0),
+      totalTradingVolume: bonuses.reduce((s, b) => s + Number(b.tradingVolume), 0),
+      byStatus: {
+        [BonusStatus.PENDING]: bonuses.filter(b => b.status === BonusStatus.PENDING).length,
+        [BonusStatus.PAID]: bonuses.filter(b => b.status === BonusStatus.PAID).length,
+        [BonusStatus.CANCELLED]: bonuses.filter(b => b.status === BonusStatus.CANCELLED).length,
+      },
+    };
+
+    return summary;
+  }
+}


### PR DESCRIPTION
## Summary

Implements a volume-based trading bonuses system with monthly payout processing and automated tier calculation.

## Changes

- `src/trading-bonuses/entities/trading-bonus.entity.ts` — `TradingBonus` entity with PENDING/PAID/CANCELLED status
- `src/trading-bonuses/dto/trading-bonus.dto.ts` — Validated request DTOs
- `src/trading-bonuses/trading-bonuses.service.ts` — Core service with bonus calc, payout processing, history
- `src/trading-bonuses/trading-bonuses.controller.ts` — REST endpoints
- `src/trading-bonuses/trading-bonuses.module.ts` — Module registration
- `src/trading-bonuses/trading-bonuses.service.spec.ts` — 9 unit tests covering all tier boundaries
- `src/app.module.ts` — Module and entity registered

## Bonus Tiers

| Trading Volume | Bonus Rate |
|----------------|-----------|
| < $1,000 | 0% |
| $1,000 – $9,999 | 1% |
| $10,000 – $99,999 | 2% |
| ≥ $100,000 | 3% |

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/trading-bonuses/calculate` | Calculate/recalculate bonus for user+month |
| POST | `/trading-bonuses/payouts/:month` | Process all pending payouts for a month |
| GET | `/trading-bonuses/user/:userId` | Paginated bonus history |
| GET | `/trading-bonuses/summary/:month` | Admin: month summary stats |

## Test Plan

- [ ] `npm test` passes all 9 bonus tier unit tests
- [ ] Volume < $1k returns 0% bonus
- [ ] Volume ≥ $100k returns 3% bonus rate
- [ ] Monthly payout marks PENDING bonuses as PAID
- [ ] Zero-amount bonuses are auto-cancelled on payout

Closes #329