### PR TITLE
feat: Prevent unauthorized access to internal services

### DIFF
--- a/src/common/decorators/internal-only.decorator.ts
+++ b/src/common/decorators/internal-only.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const INTERNAL_ONLY_KEY = 'internalOnly';
+
+/**
+ * Marks a controller endpoint or an entire controller as internal-only.
+ *
+ * When applied, the InternalServiceGuard will reject any HTTP request
+ * that does not originate from an internal source (trusted X-Internal-Request
+ * header + shared secret, or a loopback IP address).
+ *
+ * Usage:
+ * @InternalOnly()
+ * @Get('internal/metrics')
+ * getMetrics() { ... }
+ */
+export const InternalOnly = () => SetMetadata(INTERNAL_ONLY_KEY, true);

--- a/src/common/guards/internal-service.guard.ts
+++ b/src/common/guards/internal-service.guard.ts
@@ -1,0 +1,73 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { INTERNAL_ONLY_KEY } from '../decorators/internal-only.decorator';
+
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost']);
+
+/**
+ * InternalServiceGuard
+ *
+ * Protects endpoints decorated with @InternalOnly() from public access.
+ *
+ * An internal request is one that satisfies AT LEAST ONE of:
+ * 1. Originates from a loopback address (127.0.0.1, ::1) — intra-service calls
+ * 2. Includes a valid `X-Internal-Request: <INTERNAL_API_SECRET>` header
+ *
+ * This prevents internal service methods from being accidentally exposed
+ * to the public internet through controllers.
+ */
+@Injectable()
+export class InternalServiceGuard implements CanActivate {
+  private readonly logger = new Logger(InternalServiceGuard.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const isInternal = this.reflector.getAllAndOverride<boolean>(INTERNAL_ONLY_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    // Not an internal endpoint — allow through
+    if (!isInternal) return true;
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const clientIp = this.extractIp(request);
+
+    // ── Check 1: loopback address ──────────────────────────────────────────
+    if (LOOPBACK_ADDRESSES.has(clientIp)) {
+      this.logger.debug(`[InternalServiceGuard] Loopback access granted | ip=${clientIp} | ${request.path}`);
+      return true;
+    }
+
+    // ── Check 2: shared internal secret header ─────────────────────────────
+    const internalSecret = process.env.INTERNAL_API_SECRET;
+    const providedSecret = request.headers['x-internal-request'] as string | undefined;
+
+    if (internalSecret && providedSecret && providedSecret === internalSecret) {
+      this.logger.debug(`[InternalServiceGuard] Secret header access granted | ip=${clientIp} | ${request.path}`);
+      return true;
+    }
+
+    // ── Denied ─────────────────────────────────────────────────────────────
+    this.logger.warn(
+      `[InternalServiceGuard] BLOCKED public access to internal endpoint | ip=${clientIp} | ${request.method} ${request.path}`,
+    );
+    throw new ForbiddenException('This endpoint is restricted to internal services.');
+  }
+
+  private extractIp(request: Request): string {
+    const forwarded = request.headers['x-forwarded-for'];
+    if (forwarded) {
+      return (Array.isArray(forwarded) ? forwarded[0] : forwarded).split(',')[0].trim();
+    }
+    return request.ip ?? request.socket?.remoteAddress ?? 'unknown';
+  }
+}

--- a/src/common/interceptors/service-boundary.interceptor.ts
+++ b/src/common/interceptors/service-boundary.interceptor.ts
@@ -1,0 +1,43 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { INTERNAL_ONLY_KEY } from '../decorators/internal-only.decorator';
+
+/**
+ * ServiceBoundaryInterceptor
+ *
+ * Logs every request to @InternalOnly() endpoints so that
+ * accidental public exposure is always traceable in the logs.
+ *
+ * Unlike InternalServiceGuard (which enforces the boundary),
+ * this interceptor runs after the guard passes and records
+ * which internal service methods were accessed, by whom, and when.
+ */
+@Injectable()
+export class ServiceBoundaryInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(ServiceBoundaryInterceptor.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const isInternal = this.reflector.getAllAndOverride<boolean>(INTERNAL_ONLY_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isInternal) {
+      const req = context.switchToHttp().getRequest();
+      this.logger.verbose(
+        `[ServiceBoundary] Internal endpoint accessed | ${req.method} ${req.path} | ip=${req.ip}`,
+      );
+    }
+
+    return next.handle();
+  }
+}

--- a/src/common/security/service-boundary.spec.ts
+++ b/src/common/security/service-boundary.spec.ts
@@ -1,0 +1,66 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { InternalServiceGuard } from '../guards/internal-service.guard';
+
+function buildContext(ip: string, internalHeader?: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({
+        ip,
+        headers: internalHeader ? { 'x-internal-request': internalHeader } : {},
+        method: 'GET',
+        path: '/internal/metrics',
+        socket: { remoteAddress: ip },
+      }),
+    }),
+    getHandler: () => ({}),
+    getClass: () => ({}),
+  } as unknown as ExecutionContext;
+}
+
+describe('InternalServiceGuard', () => {
+  let guard: InternalServiceGuard;
+
+  beforeEach(() => {
+    const reflector = { getAllAndOverride: jest.fn().mockReturnValue(true) } as unknown as Reflector;
+    guard = new InternalServiceGuard(reflector);
+  });
+
+  afterEach(() => {
+    delete process.env.INTERNAL_API_SECRET;
+  });
+
+  it('should allow loopback (127.0.0.1) access', () => {
+    expect(guard.canActivate(buildContext('127.0.0.1'))).toBe(true);
+  });
+
+  it('should allow loopback (::1) access', () => {
+    expect(guard.canActivate(buildContext('::1'))).toBe(true);
+  });
+
+  it('should allow loopback (::ffff:127.0.0.1) access', () => {
+    expect(guard.canActivate(buildContext('::ffff:127.0.0.1'))).toBe(true);
+  });
+
+  it('should block public IP without internal secret header', () => {
+    expect(() => guard.canActivate(buildContext('203.0.113.5'))).toThrow(ForbiddenException);
+  });
+
+  it('should allow public IP with valid internal secret header', () => {
+    process.env.INTERNAL_API_SECRET = 'super-secret';
+    expect(guard.canActivate(buildContext('203.0.113.5', 'super-secret'))).toBe(true);
+  });
+
+  it('should block public IP with wrong internal secret header', () => {
+    process.env.INTERNAL_API_SECRET = 'super-secret';
+    expect(() => guard.canActivate(buildContext('203.0.113.5', 'wrong-secret'))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('should pass through non-internal endpoints without checks', () => {
+    const reflector = { getAllAndOverride: jest.fn().mockReturnValue(false) } as unknown as Reflector;
+    const publicGuard = new InternalServiceGuard(reflector);
+    expect(publicGuard.canActivate(buildContext('203.0.113.5'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a service boundary enforcement layer that prevents internal-only NestJS endpoints from being accidentally exposed to the public internet.

## Changes

- `src/common/decorators/internal-only.decorator.ts` — `@InternalOnly()` decorator using `SetMetadata`
- `src/common/guards/internal-service.guard.ts` — `InternalServiceGuard` that enforces the boundary via loopback IP check + shared secret header
- `src/common/interceptors/service-boundary.interceptor.ts` — `ServiceBoundaryInterceptor` that logs all internal endpoint access for auditability
- `src/common/security/service-boundary.spec.ts` — 7 unit tests

## Usage

```typescript
@InternalOnly()
@UseGuards(InternalServiceGuard)
@Get('internal/metrics')
getMetrics() { ... }
```

## Access Rules

| Source | Access |
|--------|--------|
| Loopback IP (127.0.0.1, ::1) | Allowed |
| Any IP + valid `X-Internal-Request` header | Allowed |
| Public IP, no/wrong header | 403 Forbidden |

## Test Plan

- [ ] `npm test` passes all 7 boundary tests
- [ ] 127.0.0.1 and ::1 are allowed without headers
- [ ] Public IP without correct header returns 403
- [ ] Public IP with correct `INTERNAL_API_SECRET` returns 200
- [ ] Non-internal endpoints pass through with no checks

Closes #351