### PR TITLE
Add AI trading assistant module

### DIFF
--- a/src/ai-trading-assistant/ai-trading-assistant.controller.spec.ts
+++ b/src/ai-trading-assistant/ai-trading-assistant.controller.spec.ts
@@ -1,0 +1,42 @@
+import { AiTradingAssistantController } from './ai-trading-assistant.controller';
+import { AiTradingAssistantService } from './ai-trading-assistant.service';
+
+describe('AiTradingAssistantController', () => {
+  let controller: AiTradingAssistantController;
+
+  beforeEach(() => {
+    controller = new AiTradingAssistantController(
+      new AiTradingAssistantService(),
+    );
+  });
+
+  it('handles assistant questions through the REST controller', () => {
+    const response = controller.ask({
+      userId: 'controller-user',
+      sessionId: 'controller-session',
+      message: 'Explain SwapTrade platform features',
+      tradingHistory: [],
+      portfolio: [],
+    });
+
+    expect(response.answer).toContain('Welcome to SwapTrade');
+    expect(response.sessionContext).toEqual({
+      sessionId: 'controller-session',
+      messageCount: 1,
+    });
+  });
+
+  it('returns risk warnings through the REST controller', () => {
+    const response = controller.assessTradeRisk({
+      userId: 'controller-user',
+      asset: 'BTC',
+      tradeType: 'LONG',
+      notionalValue: 10000,
+      leverage: 15,
+      portfolioAllocationPercent: 50,
+    });
+
+    expect(response.shouldWarn).toBe(true);
+    expect(response.warnings.join(' ')).toContain('15x leveraged BTC trade');
+  });
+});

--- a/src/ai-trading-assistant/ai-trading-assistant.controller.ts
+++ b/src/ai-trading-assistant/ai-trading-assistant.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { AiTradingAssistantService } from './ai-trading-assistant.service';
+import { AssistantQueryDto } from './dto/assistant-query.dto';
+import { RiskWarningDto } from './dto/risk-warning.dto';
+
+@Controller('ai-trading-assistant')
+export class AiTradingAssistantController {
+  constructor(
+    private readonly aiTradingAssistantService: AiTradingAssistantService,
+  ) {}
+
+  @Post('ask')
+  ask(@Body() dto: AssistantQueryDto) {
+    return this.aiTradingAssistantService.ask(dto);
+  }
+
+  @Post('risk-warning')
+  assessTradeRisk(@Body() dto: RiskWarningDto) {
+    return this.aiTradingAssistantService.assessTradeRisk(dto);
+  }
+
+  @Get('sessions/:sessionId/history')
+  getSessionHistory(@Param('sessionId') sessionId: string) {
+    return this.aiTradingAssistantService.getSessionHistory(sessionId);
+  }
+
+  @Get('interactions')
+  getInteractionLogs() {
+    return this.aiTradingAssistantService.getInteractionLogs();
+  }
+}

--- a/src/ai-trading-assistant/ai-trading-assistant.module.ts
+++ b/src/ai-trading-assistant/ai-trading-assistant.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AiTradingAssistantController } from './ai-trading-assistant.controller';
+import { AiTradingAssistantService } from './ai-trading-assistant.service';
+
+@Module({
+  controllers: [AiTradingAssistantController],
+  providers: [AiTradingAssistantService],
+  exports: [AiTradingAssistantService],
+})
+export class AiTradingAssistantModule {}

--- a/src/ai-trading-assistant/ai-trading-assistant.service.spec.ts
+++ b/src/ai-trading-assistant/ai-trading-assistant.service.spec.ts
@@ -1,0 +1,147 @@
+import { AiTradingAssistantService } from './ai-trading-assistant.service';
+
+describe('AiTradingAssistantService', () => {
+  let service: AiTradingAssistantService;
+
+  beforeEach(() => {
+    service = new AiTradingAssistantService();
+  });
+
+  it('provides onboarding guidance for new users', () => {
+    const response = service.ask({
+      userId: 'new-user',
+      sessionId: 'session-1',
+      message: 'How should I start using platform features?',
+      tradingHistory: [],
+      portfolio: [],
+    });
+
+    expect(response.profile.experienceLevel).toBe('NEW');
+    expect(response.answer).toContain('Welcome to SwapTrade');
+    expect(response.educationalContent).toContain(
+      'Review order types, balances, and risk warnings before increasing trade size.',
+    );
+  });
+
+  it('answers common platform feature questions with educational guardrails', () => {
+    const response = service.ask({
+      userId: 'user-1',
+      sessionId: 'session-1',
+      message: 'What platform features help me understand risk?',
+      tradingHistory: [
+        {
+          asset: 'BTC',
+          tradeType: 'BUY',
+          notionalValue: 100,
+          leverage: 1,
+        },
+      ],
+      portfolio: [{ asset: 'BTC', allocationPercent: 20 }],
+    });
+
+    expect(response.answer).toContain('SwapTrade supports trading workflows');
+    expect(response.answer).toContain(
+      'does not provide personalized financial advice',
+    );
+  });
+
+  it('refuses direct financial advice while offering education', () => {
+    const response = service.ask({
+      userId: 'user-2',
+      sessionId: 'session-2',
+      message: 'Should I buy BTC for guaranteed profit?',
+      tradingHistory: [
+        {
+          asset: 'BTC',
+          tradeType: 'BUY',
+          notionalValue: 1000,
+          leverage: 2,
+        },
+      ],
+      portfolio: [{ asset: 'BTC', allocationPercent: 20 }],
+    });
+
+    expect(response.answer).toContain('I cannot tell you what to buy');
+    expect(response.answer).toContain('Educational information only');
+  });
+
+  it('triggers high-risk warnings for leveraged concentrated trades', () => {
+    const result = service.assessTradeRisk({
+      userId: 'user-3',
+      asset: 'ETH',
+      tradeType: 'LONG',
+      notionalValue: 5000,
+      leverage: 12,
+      portfolioAllocationPercent: 45,
+      volatilityPercent: 70,
+    });
+
+    expect(result.shouldWarn).toBe(true);
+    expect(result.riskLevel).toBe('CRITICAL');
+    expect(result.warnings.join(' ')).toContain('12x leveraged ETH trade');
+    expect(result.educationalContent.join(' ')).toContain('Leverage increases');
+  });
+
+  it('maintains conversation context across a session', () => {
+    service.ask({
+      userId: 'user-4',
+      sessionId: 'session-4',
+      message: 'Explain portfolio risk',
+      tradingHistory: [
+        {
+          asset: 'SOL',
+          tradeType: 'LONG',
+          notionalValue: 700,
+          leverage: 6,
+          realizedPnlPercent: -18,
+        },
+      ],
+      portfolio: [{ asset: 'SOL', allocationPercent: 40 }],
+    });
+
+    const second = service.ask({
+      userId: 'user-4',
+      sessionId: 'session-4',
+      message: 'What should I learn next?',
+      tradingHistory: [
+        {
+          asset: 'SOL',
+          tradeType: 'LONG',
+          notionalValue: 700,
+          leverage: 6,
+          realizedPnlPercent: -18,
+        },
+      ],
+      portfolio: [{ asset: 'SOL', allocationPercent: 40 }],
+    });
+
+    expect(second.sessionContext.messageCount).toBe(2);
+    expect(service.getSessionHistory('session-4')).toHaveLength(2);
+  });
+
+  it('logs all assistant interactions for quality review', () => {
+    service.ask({
+      userId: 'user-5',
+      sessionId: 'session-5',
+      message: 'Tell me about leverage risk',
+      tradingHistory: [
+        {
+          asset: 'BTC',
+          tradeType: 'LONG',
+          notionalValue: 300,
+          leverage: 5,
+        },
+      ],
+      portfolio: [{ asset: 'BTC', allocationPercent: 25 }],
+    });
+
+    const logs = service.getInteractionLogs();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({
+      userId: 'user-5',
+      sessionId: 'session-5',
+      intent: 'portfolio_risk',
+    });
+  });
+});

--- a/src/ai-trading-assistant/ai-trading-assistant.service.ts
+++ b/src/ai-trading-assistant/ai-trading-assistant.service.ts
@@ -1,0 +1,360 @@
+import { Injectable } from '@nestjs/common';
+import { AssistantQueryDto } from './dto/assistant-query.dto';
+import { RiskWarningDto } from './dto/risk-warning.dto';
+import {
+  AssistantInteraction,
+  AssistantRiskLevel,
+  PortfolioPosition,
+  RiskWarningResult,
+  TradingActivity,
+  UserTradingProfile,
+} from './interfaces/ai-trading-assistant.interface';
+
+@Injectable()
+export class AiTradingAssistantService {
+  private readonly interactions: AssistantInteraction[] = [];
+  private readonly sessionMemory = new Map<string, AssistantInteraction[]>();
+
+  ask(dto: AssistantQueryDto): {
+    answer: string;
+    profile: UserTradingProfile;
+    riskLevel: AssistantRiskLevel;
+    warnings: string[];
+    educationalContent: string[];
+    sessionContext: { sessionId: string; messageCount: number };
+  } {
+    const profile = this.buildUserProfile(
+      dto.userId,
+      dto.tradingHistory ?? [],
+      dto.portfolio ?? [],
+    );
+    const risk = this.evaluateProfileRisk(profile, dto.portfolio ?? []);
+    const intent = this.detectIntent(dto.message);
+    const answer = this.buildEducationalAnswer(
+      dto.message,
+      intent,
+      profile,
+      risk,
+    );
+
+    const interaction = this.logInteraction({
+      userId: dto.userId,
+      sessionId: dto.sessionId,
+      message: dto.message,
+      response: answer,
+      intent,
+      riskLevel: risk.riskLevel,
+      warnings: risk.warnings,
+      educationalContent: risk.educationalContent,
+    });
+
+    return {
+      answer,
+      profile,
+      riskLevel: risk.riskLevel,
+      warnings: risk.warnings,
+      educationalContent: risk.educationalContent,
+      sessionContext: {
+        sessionId: dto.sessionId,
+        messageCount: this.getSessionHistory(dto.sessionId).length,
+      },
+    };
+  }
+
+  assessTradeRisk(dto: RiskWarningDto): RiskWarningResult {
+    const warnings: string[] = [];
+    const educationalContent: string[] = [];
+    let score = 0;
+
+    if (dto.leverage >= 10) {
+      score += 55;
+      warnings.push(
+        `This ${dto.leverage}x leveraged ${dto.asset} trade can amplify losses very quickly.`,
+      );
+      educationalContent.push(
+        'Leverage increases both gains and losses. Review liquidation thresholds, margin requirements, and position sizing before placing leveraged trades.',
+      );
+    } else if (dto.leverage >= 5) {
+      score += 35;
+      warnings.push(
+        `This trade uses ${dto.leverage}x leverage, which materially increases downside risk.`,
+      );
+    }
+
+    if ((dto.portfolioAllocationPercent ?? 0) >= 35) {
+      score += 25;
+      warnings.push(
+        `${dto.asset} would represent ${dto.portfolioAllocationPercent}% of the portfolio, creating concentration risk.`,
+      );
+      educationalContent.push(
+        'Concentration risk means one asset can dominate portfolio outcomes. Diversification can reduce single-asset dependency.',
+      );
+    }
+
+    if ((dto.volatilityPercent ?? 0) >= 60) {
+      score += 20;
+      warnings.push(
+        `${dto.asset} has elevated volatility, so price swings may be larger than expected.`,
+      );
+    }
+
+    const riskLevel = this.toRiskLevel(score);
+
+    return {
+      riskLevel,
+      shouldWarn: riskLevel === 'HIGH' || riskLevel === 'CRITICAL',
+      warnings,
+      educationalContent,
+      guardrail:
+        'Educational information only. This assistant does not provide personalized financial advice or trade recommendations.',
+    };
+  }
+
+  getSessionHistory(sessionId: string): AssistantInteraction[] {
+    return this.sessionMemory.get(sessionId) ?? [];
+  }
+
+  getInteractionLogs(): AssistantInteraction[] {
+    return [...this.interactions];
+  }
+
+  buildUserProfile(
+    userId: string,
+    tradingHistory: TradingActivity[],
+    portfolio: PortfolioPosition[],
+  ): UserTradingProfile {
+    const totalTrades = tradingHistory.length;
+    const averageLeverage =
+      totalTrades === 0
+        ? 1
+        : tradingHistory.reduce((sum, trade) => sum + trade.leverage, 0) /
+          totalTrades;
+    const highRiskTradeCount = tradingHistory.filter(
+      (trade) =>
+        trade.leverage >= 5 || Math.abs(trade.realizedPnlPercent ?? 0) >= 15,
+    ).length;
+    const dominantAssets = [...portfolio]
+      .sort((a, b) => b.allocationPercent - a.allocationPercent)
+      .slice(0, 3)
+      .map((position) => position.asset);
+
+    return {
+      userId,
+      experienceLevel: this.toExperienceLevel(totalTrades),
+      totalTrades,
+      averageLeverage: Number(averageLeverage.toFixed(2)),
+      highRiskTradeCount,
+      dominantAssets,
+      knowledgeGaps: this.detectKnowledgeGaps(
+        tradingHistory,
+        portfolio,
+        totalTrades,
+        averageLeverage,
+      ),
+    };
+  }
+
+  private evaluateProfileRisk(
+    profile: UserTradingProfile,
+    portfolio: PortfolioPosition[],
+  ): RiskWarningResult {
+    const concentration = portfolio.some(
+      (position) => position.allocationPercent >= 35,
+    );
+    const warnings: string[] = [];
+    const educationalContent = this.educationForGaps(profile.knowledgeGaps);
+    let score = 0;
+
+    if (profile.averageLeverage >= 5) {
+      score += 45;
+      warnings.push(
+        `Your recent average leverage is ${profile.averageLeverage}x, so losses can compound quickly.`,
+      );
+    }
+
+    if (profile.highRiskTradeCount >= 2) {
+      score += 30;
+      warnings.push(
+        `${profile.highRiskTradeCount} recent trades match high-risk behavior patterns.`,
+      );
+    }
+
+    if (concentration) {
+      score += 20;
+      warnings.push(
+        'Portfolio concentration is elevated in one or more assets.',
+      );
+    }
+
+    return {
+      riskLevel: this.toRiskLevel(score),
+      shouldWarn: score >= 60,
+      warnings,
+      educationalContent,
+      guardrail:
+        'Educational information only. This assistant does not provide personalized financial advice or trade recommendations.',
+    };
+  }
+
+  private buildEducationalAnswer(
+    message: string,
+    intent: string,
+    profile: UserTradingProfile,
+    risk: RiskWarningResult,
+  ): string {
+    if (this.requestsFinancialAdvice(message)) {
+      return [
+        'I cannot tell you what to buy, sell, hold, or size.',
+        'I can explain platform features, risk concepts, and educational factors to review before you make your own decision.',
+        risk.guardrail,
+      ].join(' ');
+    }
+
+    if (profile.totalTrades === 0) {
+      return [
+        'Welcome to SwapTrade. Start by learning how orders, portfolio allocation, and risk warnings work before placing leveraged trades.',
+        'A good onboarding path is: review platform features, understand leverage and liquidation risk, then practice with small educational examples.',
+        risk.guardrail,
+      ].join(' ');
+    }
+
+    if (intent === 'platform_features') {
+      return [
+        'SwapTrade supports trading workflows such as order placement, portfolio tracking, risk checks, analytics, and real-time updates.',
+        'This assistant can explain those features and highlight educational risk considerations based on your recent activity.',
+        risk.guardrail,
+      ].join(' ');
+    }
+
+    if (intent === 'portfolio_risk') {
+      return [
+        `Your profile shows ${profile.totalTrades} tracked trades, ${profile.averageLeverage}x average leverage, and ${profile.highRiskTradeCount} high-risk pattern(s).`,
+        risk.warnings.length
+          ? `Educational warning: ${risk.warnings.join(' ')}`
+          : 'No high-risk profile warning was detected from the supplied activity.',
+        risk.guardrail,
+      ].join(' ');
+    }
+
+    return [
+      'I can help explain trading concepts, platform features, portfolio risk signals, and educational next steps.',
+      profile.knowledgeGaps.length
+        ? `Suggested learning areas: ${profile.knowledgeGaps.join(', ')}.`
+        : 'Your supplied activity does not show a major learning gap yet.',
+      risk.guardrail,
+    ].join(' ');
+  }
+
+  private logInteraction(
+    input: Omit<AssistantInteraction, 'id' | 'createdAt'>,
+  ) {
+    const interaction: AssistantInteraction = {
+      id: `assistant-${this.interactions.length + 1}`,
+      createdAt: new Date().toISOString(),
+      ...input,
+    };
+
+    this.interactions.push(interaction);
+    const history = this.sessionMemory.get(input.sessionId) ?? [];
+    history.push(interaction);
+    this.sessionMemory.set(input.sessionId, history);
+
+    return interaction;
+  }
+
+  private detectIntent(message: string): string {
+    const normalized = message.toLowerCase();
+
+    if (
+      normalized.includes('feature') ||
+      normalized.includes('platform') ||
+      normalized.includes('how does swaptrade')
+    ) {
+      return 'platform_features';
+    }
+
+    if (
+      normalized.includes('portfolio') ||
+      normalized.includes('risk') ||
+      normalized.includes('leverage')
+    ) {
+      return 'portfolio_risk';
+    }
+
+    return 'general_education';
+  }
+
+  private requestsFinancialAdvice(message: string): boolean {
+    const normalized = message.toLowerCase();
+    return [
+      'should i buy',
+      'should i sell',
+      'what should i buy',
+      'what should i sell',
+      'guaranteed profit',
+      'tell me the best trade',
+    ].some((phrase) => normalized.includes(phrase));
+  }
+
+  private detectKnowledgeGaps(
+    tradingHistory: TradingActivity[],
+    portfolio: PortfolioPosition[],
+    totalTrades: number,
+    averageLeverage: number,
+  ): string[] {
+    const gaps = new Set<string>();
+
+    if (totalTrades < 3) {
+      gaps.add('platform onboarding');
+    }
+
+    if (averageLeverage >= 5) {
+      gaps.add('leverage and liquidation risk');
+    }
+
+    if (portfolio.some((position) => position.allocationPercent >= 35)) {
+      gaps.add('portfolio concentration');
+    }
+
+    if (
+      tradingHistory.some(
+        (trade) => Math.abs(trade.realizedPnlPercent ?? 0) >= 15,
+      )
+    ) {
+      gaps.add('volatility and drawdown management');
+    }
+
+    return [...gaps];
+  }
+
+  private educationForGaps(gaps: string[]): string[] {
+    const content: Record<string, string> = {
+      'platform onboarding':
+        'Review order types, balances, and risk warnings before increasing trade size.',
+      'leverage and liquidation risk':
+        'Leveraged trades can be liquidated when collateral no longer supports the open position.',
+      'portfolio concentration':
+        'A concentrated portfolio depends heavily on one asset, which can increase drawdown risk.',
+      'volatility and drawdown management':
+        'Volatility can create rapid unrealized losses. Track drawdown and position size together.',
+    };
+
+    return gaps.map((gap) => content[gap]).filter(Boolean);
+  }
+
+  private toExperienceLevel(
+    totalTrades: number,
+  ): UserTradingProfile['experienceLevel'] {
+    if (totalTrades === 0) return 'NEW';
+    if (totalTrades < 10) return 'DEVELOPING';
+    if (totalTrades < 50) return 'ACTIVE';
+    return 'ADVANCED';
+  }
+
+  private toRiskLevel(score: number): AssistantRiskLevel {
+    if (score >= 80) return 'CRITICAL';
+    if (score >= 60) return 'HIGH';
+    if (score >= 30) return 'MEDIUM';
+    return 'LOW';
+  }
+}

--- a/src/ai-trading-assistant/dto/assistant-query.dto.ts
+++ b/src/ai-trading-assistant/dto/assistant-query.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class TradingActivityDto {
+  @IsString()
+  asset: string;
+
+  @IsString()
+  tradeType: string;
+
+  @IsNumber()
+  @IsPositive()
+  notionalValue: number;
+
+  @IsNumber()
+  @Min(1)
+  leverage: number;
+
+  @IsOptional()
+  @IsNumber()
+  realizedPnlPercent?: number;
+
+  @IsOptional()
+  @IsString()
+  createdAt?: string;
+}
+
+export class PortfolioPositionDto {
+  @IsString()
+  asset: string;
+
+  @IsNumber()
+  @Min(0)
+  allocationPercent: number;
+
+  @IsOptional()
+  @IsNumber()
+  volatilityPercent?: number;
+}
+
+export class AssistantQueryDto {
+  @IsString()
+  userId: string;
+
+  @IsString()
+  sessionId: string;
+
+  @IsString()
+  message: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TradingActivityDto)
+  tradingHistory?: TradingActivityDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PortfolioPositionDto)
+  portfolio?: PortfolioPositionDto[];
+}

--- a/src/ai-trading-assistant/dto/risk-warning.dto.ts
+++ b/src/ai-trading-assistant/dto/risk-warning.dto.ts
@@ -1,0 +1,35 @@
+import {
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class RiskWarningDto {
+  @IsString()
+  userId: string;
+
+  @IsString()
+  asset: string;
+
+  @IsString()
+  tradeType: string;
+
+  @IsNumber()
+  @IsPositive()
+  notionalValue: number;
+
+  @IsNumber()
+  @Min(1)
+  leverage: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  portfolioAllocationPercent?: number;
+
+  @IsOptional()
+  @IsNumber()
+  volatilityPercent?: number;
+}

--- a/src/ai-trading-assistant/interfaces/ai-trading-assistant.interface.ts
+++ b/src/ai-trading-assistant/interfaces/ai-trading-assistant.interface.ts
@@ -1,0 +1,47 @@
+export type AssistantRiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export interface TradingActivity {
+  asset: string;
+  tradeType: string;
+  notionalValue: number;
+  leverage: number;
+  realizedPnlPercent?: number;
+  createdAt?: string;
+}
+
+export interface PortfolioPosition {
+  asset: string;
+  allocationPercent: number;
+  volatilityPercent?: number;
+}
+
+export interface UserTradingProfile {
+  userId: string;
+  experienceLevel: 'NEW' | 'DEVELOPING' | 'ACTIVE' | 'ADVANCED';
+  totalTrades: number;
+  averageLeverage: number;
+  highRiskTradeCount: number;
+  dominantAssets: string[];
+  knowledgeGaps: string[];
+}
+
+export interface RiskWarningResult {
+  riskLevel: AssistantRiskLevel;
+  shouldWarn: boolean;
+  warnings: string[];
+  educationalContent: string[];
+  guardrail: string;
+}
+
+export interface AssistantInteraction {
+  id: string;
+  userId: string;
+  sessionId: string;
+  message: string;
+  response: string;
+  intent: string;
+  riskLevel: AssistantRiskLevel;
+  warnings: string[];
+  educationalContent: string[];
+  createdAt: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { AppService } from './app.service';
 import { InfrastructureModule } from './infrastructure/infrastructure.module';
 
 import { AdvancedAnalyticsModule } from './advanced-analytics/advanced-analytics.module';
+import { AiTradingAssistantModule } from './ai-trading-assistant/ai-trading-assistant.module';
 
 // Phase 2 — Identity Domain
 import { IdentityModule } from './identity/identity.module';
@@ -90,9 +91,7 @@ import { ExchangeModule } from './exchange/exchange.module';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
-        type: configService.get<string>('DB_TYPE', 'postgres') as
-          | ''
-          | 'sqlite',
+        type: configService.get<string>('DB_TYPE', 'postgres') as '' | 'sqlite',
         host: configService.get<string>('DB_HOST', 'localhost'),
         port: configService.get<number>('DB_PORT', 5432),
         username: configService.get<string>('DB_USERNAME', 'postgres'),
@@ -151,6 +150,9 @@ import { ExchangeModule } from './exchange/exchange.module';
 
     // ── Trading Features — Advanced Order Types (issue #382) ──
     OrdersModule,
+
+    // ── AI Features — Trading Assistant (issue #395) ──
+    AiTradingAssistantModule,
 
     // ── Error Handling ──
     ErrorModule,


### PR DESCRIPTION
## Summary

Implements a focused AI Trading Assistant backend module for #395 with deterministic educational responses, user profiling, risk warnings, conversation context, and interaction logging.

## Changes

- Added `AiTradingAssistantModule` with service/controller wiring.
- Added endpoints for assistant questions, risk-warning checks, session history, and interaction review.
- Added DTOs and interfaces for trading activity, portfolio context, risk checks, assistant interactions, and user profiles.
- Added financial-advice guardrails so the assistant redirects buy/sell/profit requests to educational guidance.
- Added focused Jest coverage for service behavior and controller wiring.

## Testing / Verification

Passed:

```text
npm test -- src/ai-trading-assistant/ai-trading-assistant.service.spec.ts src/ai-trading-assistant/ai-trading-assistant.controller.spec.ts --runInBand
Test Suites: 2 passed, 2 total
Tests: 8 passed, 8 total
```

Passed:

```text
npx prettier --check src/ai-trading-assistant/**/*.ts src/app.module.ts
All matched files use Prettier code style!
```

Passed:

```text
npx tsc --noEmit --skipLibCheck --experimentalDecorators --emitDecoratorMetadata --target es2021 --module commonjs --moduleResolution node --esModuleInterop src/ai-trading-assistant/ai-trading-assistant.controller.ts src/ai-trading-assistant/ai-trading-assistant.module.ts src/ai-trading-assistant/ai-trading-assistant.service.ts src/ai-trading-assistant/dto/assistant-query.dto.ts src/ai-trading-assistant/dto/risk-warning.dto.ts
```

Known repo baseline gap: `npm run build` and the full Jest suite currently fail on existing unrelated errors such as governance imports, config/test setup, uuid ESM parsing, and existing assertion mismatches. The new assistant files pass targeted tests and targeted TypeScript checking.

Closes #395